### PR TITLE
Feature/spacio 48/get environment details

### DIFF
--- a/src/Application/Commands/Concretes/GetAllEnvironmentsCommand.cs
+++ b/src/Application/Commands/Concretes/GetAllEnvironmentsCommand.cs
@@ -6,27 +6,18 @@ using EnvironmentsService.src.Domain.Interfaces;
 
 namespace EnvironmentsService.Src.Application.Commands.Concretes;
 
-public class GetAllEnvironmentsCommand : ICommand<PagedResult<GetAllEnvironmentDto>>
+public class GetAllEnvironmentsCommand(
+    IEnvironmentRepository repository,
+    IMapper mapper,
+    GetAvailableEnvironmentsRequest request,
+    int page,
+    int limit) : ICommand<PagedResult<GetAllEnvironmentDto>>
 {
-    private readonly IEnvironmentRepository _repository;
-    private readonly IMapper _mapper;
-    private readonly GetAvailableEnvironmentsRequest _request;
-    private readonly int _page;
-    private readonly int _limit;
-
-    public GetAllEnvironmentsCommand(
-        IEnvironmentRepository repository,
-        IMapper mapper,
-        GetAvailableEnvironmentsRequest request,
-        int page,
-        int limit)
-    {
-        _repository = repository;
-        _mapper = mapper;
-        _request = request;
-        _page = page;
-        _limit = limit;
-    }
+    private readonly IEnvironmentRepository _repository = repository;
+    private readonly IMapper _mapper = mapper;
+    private readonly GetAvailableEnvironmentsRequest _request = request;
+    private readonly int _page = page;
+    private readonly int _limit = limit;
 
     public async Task<PagedResult<GetAllEnvironmentDto>> ExecuteAsync()
     {

--- a/src/Application/Commands/Concretes/GetAllEnvironmentsCommand.cs
+++ b/src/Application/Commands/Concretes/GetAllEnvironmentsCommand.cs
@@ -1,0 +1,45 @@
+using AutoMapper;
+using EnvironmentsService.Src.Application.Commands.Interfaces;
+using EnvironmentsService.Src.Application.DTOs.Get;
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.src.Domain.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Commands.Concretes;
+
+public class GetAllEnvironmentsCommand : ICommand<PagedResult<GetAllEnvironmentDto>>
+{
+    private readonly IEnvironmentRepository _repository;
+    private readonly IMapper _mapper;
+    private readonly GetAvailableEnvironmentsRequest _request;
+    private readonly int _page;
+    private readonly int _limit;
+
+    public GetAllEnvironmentsCommand(
+        IEnvironmentRepository repository,
+        IMapper mapper,
+        GetAvailableEnvironmentsRequest request,
+        int page,
+        int limit)
+    {
+        _repository = repository;
+        _mapper = mapper;
+        _request = request;
+        _page = page;
+        _limit = limit;
+    }
+
+    public async Task<PagedResult<GetAllEnvironmentDto>> ExecuteAsync()
+    {
+        var (environments, totalItems) = await _repository.FilterEnvironmentsAsync(_request, _page, _limit);
+        var dtos = _mapper.Map<List<GetAllEnvironmentDto>>(environments);
+
+        return new PagedResult<GetAllEnvironmentDto>
+        {
+            Items = dtos,
+            CurrentPage = _page,
+            TotalPages = (int)Math.Ceiling(totalItems / (double)_limit),
+            Limit = _limit,
+            TotalItems = totalItems,
+        };
+    }
+}

--- a/src/Application/Commands/Concretes/GetSingleEnvironmentCommand.cs
+++ b/src/Application/Commands/Concretes/GetSingleEnvironmentCommand.cs
@@ -5,21 +5,14 @@ using EnvironmentsService.src.Domain.Interfaces;
 
 namespace EnvironmentsService.Src.Application.Commands.Concretes;
 
-public class GetSingleEnvironmentCommand : ICommand<EnvironmentDto?>
+public class GetSingleEnvironmentCommand(
+    IEnvironmentRepository repository,
+    IMapper mapper,
+    Guid publicId) : ICommand<EnvironmentDto?>
 {
-    private readonly IEnvironmentRepository _repository;
-    private readonly IMapper _mapper;
-    private readonly Guid _publicId;
-
-    public GetSingleEnvironmentCommand(
-        IEnvironmentRepository repository,
-        IMapper mapper,
-        Guid publicId)
-    {
-        _repository = repository;
-        _mapper = mapper;
-        _publicId = publicId;
-    }
+    private readonly IEnvironmentRepository _repository = repository;
+    private readonly IMapper _mapper = mapper;
+    private readonly Guid _publicId = publicId;
 
     public async Task<EnvironmentDto?> ExecuteAsync()
     {

--- a/src/Application/Commands/Concretes/GetSingleEnvironmentCommand.cs
+++ b/src/Application/Commands/Concretes/GetSingleEnvironmentCommand.cs
@@ -1,0 +1,29 @@
+using AutoMapper;
+using EnvironmentsService.Src.Application.Commands.Interfaces;
+using EnvironmentsService.Src.Application.DTOs.Get;
+using EnvironmentsService.src.Domain.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Commands.Concretes;
+
+public class GetSingleEnvironmentCommand : ICommand<EnvironmentDto?>
+{
+    private readonly IEnvironmentRepository _repository;
+    private readonly IMapper _mapper;
+    private readonly Guid _publicId;
+
+    public GetSingleEnvironmentCommand(
+        IEnvironmentRepository repository,
+        IMapper mapper,
+        Guid publicId)
+    {
+        _repository = repository;
+        _mapper = mapper;
+        _publicId = publicId;
+    }
+
+    public async Task<EnvironmentDto?> ExecuteAsync()
+    {
+        var environment = await _repository.GetSingleEnvironment(_publicId);
+        return _mapper.Map<EnvironmentDto>(environment);
+    }
+}

--- a/src/Application/Commands/Interfaces/ICommand.cs
+++ b/src/Application/Commands/Interfaces/ICommand.cs
@@ -1,0 +1,6 @@
+namespace EnvironmentsService.Src.Application.Commands.Interfaces;
+
+public interface ICommand<TResult>
+{
+    Task<TResult> ExecuteAsync();
+}

--- a/src/Application/DTOs/Get/GetAllEnvironmentDto.cs
+++ b/src/Application/DTOs/Get/GetAllEnvironmentDto.cs
@@ -31,4 +31,6 @@ public class GetAllEnvironmentDto
     public List<string> PhotoUrls { get; set; } = [];
 
     public List<PricingPolicyDto> PricingPolicies { get; set; } = [];
+
+    public long? LastTour360Date { get; set; }
 }

--- a/src/Application/Interfaces/IEnvironmentService.cs
+++ b/src/Application/Interfaces/IEnvironmentService.cs
@@ -7,5 +7,5 @@ public interface IEnvironmentService
 {
     Task<PagedResult<GetAllEnvironmentDto>> GetAvailableEnvironmentsAsync(GetAvailableEnvironmentsRequest request, int page, int limit);
 
-    Task<EnvironmentDto?> GetSingleEnvironment(Guid publicId);
+    Task<EnvironmentDto?> GetSingleEnvironmentAsync(Guid publicId);
 }

--- a/src/Application/Mapping/EnvironmentProfile.cs
+++ b/src/Application/Mapping/EnvironmentProfile.cs
@@ -17,6 +17,7 @@ public class EnvironmentProfile : Profile
             .ForMember(dest => dest.DiscountPolicies, opt => opt.MapFrom(src => src.DiscountPolicies))
             .ForMember(dest => dest.Equipment, opt => opt.MapFrom(src => src.Equipment))
             .ForMember(dest => dest.Type, opt => opt.MapFrom(src => src.Type))
+            .ForMember(dest => dest.PhotoUrls, opt => opt.MapFrom(src => src.Photos.Select(p => p.Url)))
             .ForMember(dest => dest.LastTour360Date, opt => opt.MapFrom(src =>
                 src.Tour360Requests
                     .Where(r => r.ScheduledDate.HasValue)
@@ -27,6 +28,12 @@ public class EnvironmentProfile : Profile
         CreateMap<Environment, GetAllEnvironmentDto>()
             .ForMember(dest => dest.Type, opt => opt.MapFrom(src => src.Type))
             .ForMember(dest => dest.PricingPolicies, opt => opt.MapFrom(src => src.PricingPolicies))
+            .ForMember(dest => dest.PhotoUrls, opt => opt.MapFrom(src => src.Photos.Select(p => p.Url)))
+            .ForMember(dest => dest.LastTour360Date, opt => opt.MapFrom(src =>
+                src.Tour360Requests
+                    .Where(r => r.ScheduledDate.HasValue)
+                    .OrderByDescending(r => r.ScheduledDate)
+                    .FirstOrDefault()))
             .ReverseMap();
 
         CreateMap<Area, AreaDto>().ReverseMap();

--- a/src/Application/Pipelines/EnvironmentFilterPipeline.cs
+++ b/src/Application/Pipelines/EnvironmentFilterPipeline.cs
@@ -1,0 +1,26 @@
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Pipelines;
+
+public class EnvironmentFilterPipeline
+{
+    private readonly IEnumerable<IEnvironmentFilterStrategy> _strategies;
+
+    public EnvironmentFilterPipeline(IEnumerable<IEnvironmentFilterStrategy> strategies)
+    {
+        _strategies = strategies;
+    }
+
+    public IQueryable<Domain.Entities.Environment> ApplyFilters(
+        IQueryable<Domain.Entities.Environment> query,
+        GetAvailableEnvironmentsRequest request)
+    {
+        foreach (var strategy in _strategies)
+        {
+            query = strategy.Apply(query, request);
+        }
+
+        return query;
+    }
+}

--- a/src/Application/Services/EnvironmentService.cs
+++ b/src/Application/Services/EnvironmentService.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using EnvironmentsService.Src.Application.Commands.Concretes;
 using EnvironmentsService.Src.Application.DTOs.Get;
 using EnvironmentsService.Src.Application.DTOs.GetRequest;
 using EnvironmentsService.Src.Application.Interfaces;
@@ -13,27 +14,13 @@ public class EnvironmentService(IEnvironmentRepository repository, IMapper mappe
 
     public async Task<PagedResult<GetAllEnvironmentDto>> GetAvailableEnvironmentsAsync(GetAvailableEnvironmentsRequest request, int page, int limit)
     {
-        var (environments, totalItems) = await _repository.FilterEnvironmentsAsync(request, page, limit);
-
-        int totalPages = (int)Math.Ceiling(totalItems / (double)limit);
-
-        var environmentDtos = _mapper.Map<List<GetAllEnvironmentDto>>(environments);
-
-        return new PagedResult<GetAllEnvironmentDto>
-        {
-            Items = environmentDtos,
-            CurrentPage = page,
-            TotalPages = totalPages,
-            Limit = limit,
-            TotalItems = totalItems,
-        };
+        var command = new GetAllEnvironmentsCommand(_repository, _mapper, request, page, limit);
+        return await command.ExecuteAsync();
     }
 
-    public async Task<EnvironmentDto?> GetSingleEnvironment(Guid publicId)
+    public async Task<EnvironmentDto?> GetSingleEnvironmentAsync(Guid publicId)
     {
-        var environment = await _repository.GetSingleEnvironment(publicId);
-        var environmentDto = _mapper.Map<EnvironmentDto>(environment);
-
-        return environmentDto;
+        var command = new GetSingleEnvironmentCommand(_repository, _mapper, publicId);
+        return await command.ExecuteAsync();
     }
 }

--- a/src/Application/Strategies/Concretes/GetEnvironments/AreaFilterStrategy.cs
+++ b/src/Application/Strategies/Concretes/GetEnvironments/AreaFilterStrategy.cs
@@ -1,0 +1,24 @@
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Strategies.Concretes.GetEnvironments;
+
+public class AreaFilterStrategy : IEnvironmentFilterStrategy
+{
+    public IQueryable<Domain.Entities.Environment> Apply(
+            IQueryable<Domain.Entities.Environment> query,
+            GetAvailableEnvironmentsRequest request)
+    {
+        if (request.Areas?.Count > 0)
+        {
+            foreach (var (areaPublicKey, minQuantity) in request.Areas)
+            {
+                query = query.Where(e =>
+                    e.EnvironmentAreas.Any(ea =>
+                        ea.Area.PublicKey == areaPublicKey && ea.Quantity >= minQuantity));
+            }
+        }
+
+        return query;
+    }
+}

--- a/src/Application/Strategies/Concretes/GetEnvironments/CapacityFilterStrategy.cs
+++ b/src/Application/Strategies/Concretes/GetEnvironments/CapacityFilterStrategy.cs
@@ -1,0 +1,19 @@
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Strategies.Concretes.GetEnvironments;
+
+public class CapacityFilterStrategy : IEnvironmentFilterStrategy
+{
+    public IQueryable<Domain.Entities.Environment> Apply(
+            IQueryable<Domain.Entities.Environment> query,
+            GetAvailableEnvironmentsRequest request)
+    {
+        if (request.MinCapacity.HasValue)
+        {
+            query = query.Where(e => e.Capacity >= request.MinCapacity);
+        }
+
+        return query;
+    }
+}

--- a/src/Application/Strategies/Concretes/GetEnvironments/DateAvailabilityFilterStrategy.cs
+++ b/src/Application/Strategies/Concretes/GetEnvironments/DateAvailabilityFilterStrategy.cs
@@ -1,0 +1,20 @@
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Strategies.Concretes.GetEnvironments;
+
+public class DateAvailabilityFilterStrategy : IEnvironmentFilterStrategy
+{
+    public IQueryable<Domain.Entities.Environment> Apply(
+        IQueryable<Domain.Entities.Environment> query,
+        GetAvailableEnvironmentsRequest request)
+    {
+        if (request.StartDate.HasValue && request.EndDate.HasValue)
+        {
+            query = query.Where(e => !e.NonAvailabilities.Any(n =>
+                n.StartDate <= request.StartDate && n.EndDate >= request.EndDate));
+        }
+
+        return query;
+    }
+}

--- a/src/Application/Strategies/Concretes/GetEnvironments/EnvironmentTypeFilterStrategy.cs
+++ b/src/Application/Strategies/Concretes/GetEnvironments/EnvironmentTypeFilterStrategy.cs
@@ -1,0 +1,19 @@
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Strategies.Concretes.GetEnvironments;
+
+public class EnvironmentTypeFilterStrategy : IEnvironmentFilterStrategy
+{
+    public IQueryable<Domain.Entities.Environment> Apply(
+           IQueryable<Domain.Entities.Environment> query,
+           GetAvailableEnvironmentsRequest request)
+    {
+        if (!string.IsNullOrWhiteSpace(request.EnvironmentTypePublicKey))
+        {
+            query = query.Where(e => e.Type.PublicKey == request.EnvironmentTypePublicKey);
+        }
+
+        return query;
+    }
+}

--- a/src/Application/Strategies/Concretes/GetEnvironments/InstantBookingFilterStrategy.cs
+++ b/src/Application/Strategies/Concretes/GetEnvironments/InstantBookingFilterStrategy.cs
@@ -1,0 +1,19 @@
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Strategies.Concretes.GetEnvironments;
+
+public class InstantBookingFilterStrategy : IEnvironmentFilterStrategy
+{
+    public IQueryable<Domain.Entities.Environment> Apply(
+            IQueryable<Domain.Entities.Environment> query,
+            GetAvailableEnvironmentsRequest request)
+    {
+        if (request.InstantBookingRequired.HasValue)
+        {
+            query = query.Where(e => e.InstantBooking == request.InstantBookingRequired);
+        }
+
+        return query;
+    }
+}

--- a/src/Application/Strategies/Concretes/GetEnvironments/LocationFilterStrategy.cs
+++ b/src/Application/Strategies/Concretes/GetEnvironments/LocationFilterStrategy.cs
@@ -1,0 +1,19 @@
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Strategies.Concretes.GetEnvironments;
+
+public class LocationFilterStrategy : IEnvironmentFilterStrategy
+{
+    public IQueryable<Domain.Entities.Environment> Apply(
+            IQueryable<Domain.Entities.Environment> query,
+            GetAvailableEnvironmentsRequest request)
+    {
+        if (!string.IsNullOrWhiteSpace(request.Location))
+        {
+            query = query.Where(e => e.Location.Contains(request.Location));
+        }
+
+        return query;
+    }
+}

--- a/src/Application/Strategies/Concretes/GetEnvironments/PriceFilterStrategy.cs
+++ b/src/Application/Strategies/Concretes/GetEnvironments/PriceFilterStrategy.cs
@@ -1,0 +1,22 @@
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Strategies.Concretes.GetEnvironments;
+
+public class PriceFilterStrategy : IEnvironmentFilterStrategy
+{
+    public IQueryable<Domain.Entities.Environment> Apply(
+            IQueryable<Domain.Entities.Environment> query,
+            GetAvailableEnvironmentsRequest request)
+    {
+        if (request.MinPrice.HasValue || request.MaxPrice.HasValue)
+        {
+            query = query.Where(e =>
+                e.PricingPolicies.Any(p =>
+                    (!request.MinPrice.HasValue || p.BasePrice >= request.MinPrice) &&
+                    (!request.MaxPrice.HasValue || p.BasePrice <= request.MaxPrice)));
+        }
+
+        return query;
+    }
+}

--- a/src/Application/Strategies/Concretes/GetEnvironments/ServiceFilterStrategy.cs
+++ b/src/Application/Strategies/Concretes/GetEnvironments/ServiceFilterStrategy.cs
@@ -1,0 +1,21 @@
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Strategies.Concretes.GetEnvironments;
+
+public class ServiceFilterStrategy : IEnvironmentFilterStrategy
+{
+    public IQueryable<Domain.Entities.Environment> Apply(
+            IQueryable<Domain.Entities.Environment> query,
+            GetAvailableEnvironmentsRequest request)
+    {
+        if (request.ServicePublicKeys?.Count > 0)
+        {
+            query = query.Where(e =>
+                request.ServicePublicKeys.All(reqKey =>
+                    e.EnvironmentServices.Any(es => es.Service.PublicKey == reqKey)));
+        }
+
+        return query;
+    }
+}

--- a/src/Application/Strategies/Interfaces/IEnvironmentFilterStrategy.cs
+++ b/src/Application/Strategies/Interfaces/IEnvironmentFilterStrategy.cs
@@ -1,0 +1,10 @@
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+
+namespace EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+public interface IEnvironmentFilterStrategy
+{
+    IQueryable<Src.Domain.Entities.Environment> Apply(
+            IQueryable<Src.Domain.Entities.Environment> query,
+            GetAvailableEnvironmentsRequest request);
+}

--- a/src/Infraestructure/Repositories/EnvironmentRepository.cs
+++ b/src/Infraestructure/Repositories/EnvironmentRepository.cs
@@ -94,6 +94,7 @@ public class EnvironmentRepository(DbContext context) : IEnvironmentRepository
             .Include(e => e.EnvironmentServices).ThenInclude(es => es.Service)
             .Include(e => e.EnvironmentAreas).ThenInclude(ea => ea.Area)
             .Include(e => e.NonAvailabilities)
+            .Where(e => e.Deleted == false && e.Hidden == false)
             .FirstOrDefaultAsync(e => e.PublicId == publicId);
     }
 }

--- a/src/Infraestructure/Repositories/EnvironmentRepository.cs
+++ b/src/Infraestructure/Repositories/EnvironmentRepository.cs
@@ -1,80 +1,34 @@
 using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Application.Pipelines;
 using EnvironmentsService.src.Domain.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
 namespace EnvironmentsService.src.Infraestructure.Repositories;
 
-public class EnvironmentRepository(DbContext context) : IEnvironmentRepository
+public class EnvironmentRepository(DbContext context, EnvironmentFilterPipeline pipeline) : IEnvironmentRepository
 {
     private readonly DbContext _context = context;
+    private readonly EnvironmentFilterPipeline _pipeline = pipeline;
 
     public async Task<(List<Src.Domain.Entities.Environment> Environments, int TotalItems)> FilterEnvironmentsAsync(
-    GetAvailableEnvironmentsRequest request, int page, int limit)
+        GetAvailableEnvironmentsRequest request, int page, int limit)
     {
-        var query = _context.Set<Src.Domain.Entities.Environment>()
+        var baseQuery = _context.Set<Src.Domain.Entities.Environment>()
             .Include(e => e.Type)
             .Include(e => e.PricingPolicies)
             .Include(e => e.Photos)
             .Include(e => e.EnvironmentServices).ThenInclude(es => es.Service)
             .Include(e => e.EnvironmentAreas).ThenInclude(ea => ea.Area)
             .Include(e => e.NonAvailabilities)
-            .Where(e => !e.Deleted && !e.Hidden)
+            .Where(e => e.Deleted == false)
+            .Where(e => e.Hidden == false)
             .AsQueryable();
 
-        if (!string.IsNullOrWhiteSpace(request.Location))
-        {
-            query = query.Where(e => e.Location.Contains(request.Location));
-        }
+        var filteredQuery = _pipeline.ApplyFilters(baseQuery, request);
 
-        if (!string.IsNullOrWhiteSpace(request.EnvironmentTypePublicKey))
-        {
-            query = query.Where(e => e.Type.PublicKey == request.EnvironmentTypePublicKey);
-        }
+        var totalItems = await filteredQuery.CountAsync();
 
-        if (request.InstantBookingRequired.HasValue)
-        {
-            query = query.Where(e => e.InstantBooking == request.InstantBookingRequired);
-        }
-
-        if (request.MinCapacity.HasValue)
-        {
-            query = query.Where(e => e.Capacity >= request.MinCapacity);
-        }
-
-        if (request.MinPrice.HasValue || request.MaxPrice.HasValue)
-        {
-            query = query.Where(e =>
-                e.PricingPolicies.Any(p =>
-                    (!request.MinPrice.HasValue || p.BasePrice >= request.MinPrice) &&
-                    (!request.MaxPrice.HasValue || p.BasePrice <= request.MaxPrice)));
-        }
-
-        if (request.ServicePublicKeys?.Count > 0)
-        {
-            query = query.Where(e =>
-                request.ServicePublicKeys.All(reqKey =>
-                    e.EnvironmentServices.Any(es => es.Service.PublicKey == reqKey)));
-        }
-
-        if (request.Areas?.Count > 0)
-        {
-            foreach (var (areaPublicKey, minQuantity) in request.Areas)
-            {
-                query = query.Where(e =>
-                    e.EnvironmentAreas.Any(ea =>
-                        ea.Area.PublicKey == areaPublicKey && ea.Quantity >= minQuantity));
-            }
-        }
-
-        if (request.StartDate.HasValue && request.EndDate.HasValue)
-        {
-            query = query.Where(e => !e.NonAvailabilities.Any(n =>
-                n.StartDate <= request.StartDate && n.EndDate >= request.EndDate));
-        }
-
-        var totalItems = await query.CountAsync();
-
-        var environments = await query
+        var environments = await filteredQuery
             .Skip((page - 1) * limit)
             .Take(limit)
             .ToListAsync();

--- a/src/WebApi/Controllers/EnvironmentsController.cs
+++ b/src/WebApi/Controllers/EnvironmentsController.cs
@@ -23,7 +23,7 @@ public class EnvironmentsController(IEnvironmentService service) : ControllerBas
     [HttpGet("single")]
     public async Task<IActionResult> GetAvailableEnvironments([FromQuery] Guid publicId)
     {
-        var result = await _service.GetSingleEnvironment(publicId);
+        var result = await _service.GetSingleEnvironmentAsync(publicId);
         return Ok(result);
     }
 }

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,6 +1,12 @@
+using EnvironmentsService.Src.Application.Commands.Concretes;
+using EnvironmentsService.Src.Application.Commands.Interfaces;
+using EnvironmentsService.Src.Application.DTOs.Get;
 using EnvironmentsService.Src.Application.Interfaces;
 using EnvironmentsService.Src.Application.Mapping;
+using EnvironmentsService.Src.Application.Pipelines;
 using EnvironmentsService.Src.Application.Services;
+using EnvironmentsService.Src.Application.Strategies.Concretes.GetEnvironments;
+using EnvironmentsService.Src.Application.Strategies.Interfaces;
 using EnvironmentsService.src.Domain.Interfaces;
 using EnvironmentsService.src.Infraestructure.Data;
 using EnvironmentsService.src.Infraestructure.Repositories;
@@ -28,6 +34,16 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 builder.Services.AddScoped<IEnvironmentService, EnvironmentService>();
 builder.Services.AddScoped<IEnvironmentRepository, EnvironmentRepository>();
 builder.Services.AddScoped<DbContext, AppDbContext>();
+builder.Services.AddScoped<IEnvironmentFilterStrategy, LocationFilterStrategy>();
+builder.Services.AddScoped<IEnvironmentFilterStrategy, EnvironmentTypeFilterStrategy>();
+builder.Services.AddScoped<IEnvironmentFilterStrategy, InstantBookingFilterStrategy>();
+builder.Services.AddScoped<IEnvironmentFilterStrategy, CapacityFilterStrategy>();
+builder.Services.AddScoped<IEnvironmentFilterStrategy, PriceFilterStrategy>();
+builder.Services.AddScoped<IEnvironmentFilterStrategy, ServiceFilterStrategy>();
+builder.Services.AddScoped<IEnvironmentFilterStrategy, AreaFilterStrategy>();
+builder.Services.AddScoped<IEnvironmentFilterStrategy, DateAvailabilityFilterStrategy>();
+builder.Services.AddScoped<EnvironmentFilterPipeline>();
+
 builder.Services.AddAutoMapper(typeof(EnvironmentProfile));
 
 var app = builder.Build();


### PR DESCRIPTION
### What I Did:

- Implemented the `GetSingleEnvironment` method in the `EnvironmentRepository` and `EnvironmentService`.
- Created a new API endpoint `/api/environments/single` to expose the functionality.
- Included related navigation properties in the query (Type, PricingPolicies, Photos, Areas, Services, Availabilities, etc.).
- Filtered out environments marked as `Deleted` or `Hidden`.

---

### Why I Did It:

- To allow clients (e.g., mobile/web apps) to fetch complete information about a specific environment for detailed views.
- To ensure the endpoint returns all necessary related data in one optimized query.
- To enforce visibility rules by excluding hidden or deleted environments.

---

### How I Did It:

- Used `FirstOrDefaultAsync` with a filtered LINQ query on the `Environment` DbSet.
- Applied eager loading (`.Include`) for all related entities to minimize query count.
- Ensured a clean structure by isolating the logic in the repository layer.
- Connected the endpoint to the controller and service with proper parameter validation.

---

Let me know if you'd like to include response examples or add testing notes!