### PR TITLE
Feature/spacio 180/get areas and services to show filters

### DIFF
--- a/src/Application/Commands/Concretes/GetAllEnvironmentsCommand.cs
+++ b/src/Application/Commands/Concretes/GetAllEnvironmentsCommand.cs
@@ -2,7 +2,7 @@ using AutoMapper;
 using EnvironmentsService.Src.Application.Commands.Interfaces;
 using EnvironmentsService.Src.Application.DTOs.Get;
 using EnvironmentsService.Src.Application.DTOs.GetRequest;
-using EnvironmentsService.src.Domain.Interfaces;
+using EnvironmentsService.Src.Domain.Interfaces;
 
 namespace EnvironmentsService.Src.Application.Commands.Concretes;
 

--- a/src/Application/Commands/Concretes/GetSingleEnvironmentCommand.cs
+++ b/src/Application/Commands/Concretes/GetSingleEnvironmentCommand.cs
@@ -1,7 +1,7 @@
 using AutoMapper;
 using EnvironmentsService.Src.Application.Commands.Interfaces;
 using EnvironmentsService.Src.Application.DTOs.Get;
-using EnvironmentsService.src.Domain.Interfaces;
+using EnvironmentsService.Src.Domain.Interfaces;
 
 namespace EnvironmentsService.Src.Application.Commands.Concretes;
 

--- a/src/Application/Interfaces/IAreaService.cs
+++ b/src/Application/Interfaces/IAreaService.cs
@@ -1,6 +1,6 @@
 using EnvironmentsService.Src.Application.DTOs.Get;
 
-namespace EnvironmentsService.src.Application.Interfaces;
+namespace EnvironmentsService.Src.Application.Interfaces;
 
 public interface IAreaService
 {

--- a/src/Application/Interfaces/IAreaService.cs
+++ b/src/Application/Interfaces/IAreaService.cs
@@ -1,0 +1,8 @@
+using EnvironmentsService.Src.Application.DTOs.Get;
+
+namespace EnvironmentsService.src.Application.Interfaces;
+
+public interface IAreaService
+{
+    Task<List<AreaDto>> GetAllAsync();
+}

--- a/src/Application/Interfaces/IServiceService.cs
+++ b/src/Application/Interfaces/IServiceService.cs
@@ -1,0 +1,8 @@
+using EnvironmentsService.Src.Application.DTOs.Get;
+
+namespace EnvironmentsService.src.Application.Interfaces;
+
+public interface IServiceService
+{
+    Task<ServiceDto> GetAllServicesAsync();
+}

--- a/src/Application/Interfaces/IServiceService.cs
+++ b/src/Application/Interfaces/IServiceService.cs
@@ -1,8 +1,8 @@
 using EnvironmentsService.Src.Application.DTOs.Get;
 
-namespace EnvironmentsService.src.Application.Interfaces;
+namespace EnvironmentsService.Src.Application.Interfaces;
 
 public interface IServiceService
 {
-    Task<ServiceDto> GetAllServicesAsync();
+    Task<List<ServiceDto>> GetAllAsync();
 }

--- a/src/Application/Services/AreaService.cs
+++ b/src/Application/Services/AreaService.cs
@@ -1,0 +1,18 @@
+using AutoMapper;
+using EnvironmentsService.Src.Application.DTOs.Get;
+using EnvironmentsService.src.Application.Interfaces;
+using EnvironmentsService.src.Domain.Interfaces;
+
+namespace EnvironmentsService.src.Application.Services;
+
+public class AreaService(IAreaRepository areaRepository, IMapper mapper) : IAreaService
+{
+    private readonly IAreaRepository _areaRepository = areaRepository;
+    private readonly IMapper _mapper = mapper;
+
+    public async Task<List<AreaDto>> GetAllAsync()
+    {
+        var areas = await _areaRepository.GetAllAsync();
+        return _mapper.Map<List<AreaDto>>(areas);
+    }
+}

--- a/src/Application/Services/AreaService.cs
+++ b/src/Application/Services/AreaService.cs
@@ -1,9 +1,9 @@
 using AutoMapper;
 using EnvironmentsService.Src.Application.DTOs.Get;
-using EnvironmentsService.src.Application.Interfaces;
-using EnvironmentsService.src.Domain.Interfaces;
+using EnvironmentsService.Src.Application.Interfaces;
+using EnvironmentsService.Src.Domain.Interfaces;
 
-namespace EnvironmentsService.src.Application.Services;
+namespace EnvironmentsService.Src.Application.Services;
 
 public class AreaService(IAreaRepository areaRepository, IMapper mapper) : IAreaService
 {

--- a/src/Application/Services/EnvironmentService.cs
+++ b/src/Application/Services/EnvironmentService.cs
@@ -3,7 +3,7 @@ using EnvironmentsService.Src.Application.Commands.Concretes;
 using EnvironmentsService.Src.Application.DTOs.Get;
 using EnvironmentsService.Src.Application.DTOs.GetRequest;
 using EnvironmentsService.Src.Application.Interfaces;
-using EnvironmentsService.src.Domain.Interfaces;
+using EnvironmentsService.Src.Domain.Interfaces;
 
 namespace EnvironmentsService.Src.Application.Services;
 

--- a/src/Application/Services/ServiceService.cs
+++ b/src/Application/Services/ServiceService.cs
@@ -1,0 +1,18 @@
+using AutoMapper;
+using EnvironmentsService.Src.Application.DTOs.Get;
+using EnvironmentsService.Src.Application.Interfaces;
+using EnvironmentsService.Src.Domain.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Services;
+
+public class ServiceService(IServiceRepository serviceRepository, IMapper mapper) : IServiceService
+{
+    private readonly IServiceRepository _serviceRepository = serviceRepository;
+    private readonly IMapper _mapper = mapper;
+
+    public async Task<List<ServiceDto>> GetAllAsync()
+    {
+        var services = await _serviceRepository.GetAllAsync();
+        return _mapper.Map<List<ServiceDto>>(services);
+    }
+}

--- a/src/Domain/Entities/Environment.cs
+++ b/src/Domain/Entities/Environment.cs
@@ -32,7 +32,7 @@ public class Environment
 
     public int MaxRentalTime { get; set; }
 
-    required public string RentalUnit { get; set; }
+    required public string RentalUnit { get; set; } // "hour" or "day"
 
     required public EnvironmentType Type { get; set; }
 

--- a/src/Domain/Interfaces/IAreaRepository.cs
+++ b/src/Domain/Interfaces/IAreaRepository.cs
@@ -1,6 +1,6 @@
 using EnvironmentsService.Src.Domain.Entities;
 
-namespace EnvironmentsService.src.Domain.Interfaces;
+namespace EnvironmentsService.Src.Domain.Interfaces;
 
 public interface IAreaRepository
 {

--- a/src/Domain/Interfaces/IAreaRepository.cs
+++ b/src/Domain/Interfaces/IAreaRepository.cs
@@ -1,0 +1,8 @@
+using EnvironmentsService.Src.Domain.Entities;
+
+namespace EnvironmentsService.src.Domain.Interfaces;
+
+public interface IAreaRepository
+{
+    Task<List<Area>> GetAllAsync();
+}

--- a/src/Domain/Interfaces/IEnvironmentRepository.cs
+++ b/src/Domain/Interfaces/IEnvironmentRepository.cs
@@ -1,6 +1,6 @@
 using EnvironmentsService.Src.Application.DTOs.GetRequest;
 
-namespace EnvironmentsService.src.Domain.Interfaces;
+namespace EnvironmentsService.Src.Domain.Interfaces;
 
 public interface IEnvironmentRepository
 {

--- a/src/Domain/Interfaces/IServiceRepository.cs
+++ b/src/Domain/Interfaces/IServiceRepository.cs
@@ -1,0 +1,8 @@
+using EnvironmentsService.Src.Domain.Entities;
+
+namespace EnvironmentsService.src.Domain.Interfaces;
+
+public interface IServiceRepository
+{
+    Task<Service> GetServicesAsync();
+}

--- a/src/Domain/Interfaces/IServiceRepository.cs
+++ b/src/Domain/Interfaces/IServiceRepository.cs
@@ -1,8 +1,8 @@
 using EnvironmentsService.Src.Domain.Entities;
 
-namespace EnvironmentsService.src.Domain.Interfaces;
+namespace EnvironmentsService.Src.Domain.Interfaces;
 
 public interface IServiceRepository
 {
-    Task<Service> GetServicesAsync();
+    Task<List<Service>> GetAllAsync();
 }

--- a/src/Infraestructure/Data/AppDbContext.cs
+++ b/src/Infraestructure/Data/AppDbContext.cs
@@ -1,4 +1,4 @@
-namespace EnvironmentsService.src.Infraestructure.Data;
+namespace EnvironmentsService.Src.Infraestructure.Data;
 
 using EnvironmentsService.Src.Domain.Entities;
 using Microsoft.EntityFrameworkCore;

--- a/src/Infraestructure/Repositories/AreaRepository.cs
+++ b/src/Infraestructure/Repositories/AreaRepository.cs
@@ -1,0 +1,15 @@
+using EnvironmentsService.Src.Domain.Entities;
+using EnvironmentsService.src.Domain.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace EnvironmentsService.src.Infraestructure.Repositories;
+
+public class AreaRepository(DbContext context) : IAreaRepository
+{
+    private readonly DbContext _context = context;
+
+    public async Task<List<Area>> GetAllAsync()
+    {
+        return await _context.Set<Area>().ToListAsync();
+    }
+}

--- a/src/Infraestructure/Repositories/EnvironmentRepository.cs
+++ b/src/Infraestructure/Repositories/EnvironmentRepository.cs
@@ -1,9 +1,9 @@
 using EnvironmentsService.Src.Application.DTOs.GetRequest;
 using EnvironmentsService.Src.Application.Pipelines;
-using EnvironmentsService.src.Domain.Interfaces;
+using EnvironmentsService.Src.Domain.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
-namespace EnvironmentsService.src.Infraestructure.Repositories;
+namespace EnvironmentsService.Src.Infraestructure.Repositories;
 
 public class EnvironmentRepository(DbContext context, EnvironmentFilterPipeline pipeline) : IEnvironmentRepository
 {

--- a/src/Infraestructure/Repositories/ServiceRepository.cs
+++ b/src/Infraestructure/Repositories/ServiceRepository.cs
@@ -4,12 +4,12 @@ using Microsoft.EntityFrameworkCore;
 
 namespace EnvironmentsService.Src.Infraestructure.Repositories;
 
-public class AreaRepository(DbContext context) : IAreaRepository
+public class ServiceRepository(DbContext context) : IServiceRepository
 {
     private readonly DbContext _context = context;
 
-    public async Task<List<Area>> GetAllAsync()
+    public async Task<List<Service>> GetAllAsync()
     {
-        return await _context.Set<Area>().ToListAsync();
+        return await _context.Set<Service>().ToListAsync();
     }
 }

--- a/src/WebApi/Controllers/AreasController.cs
+++ b/src/WebApi/Controllers/AreasController.cs
@@ -1,0 +1,24 @@
+namespace EnvironmentsService.src.WebApi.Controllers;
+
+using Microsoft.AspNetCore.Mvc;
+using EnvironmentsService.src.Application.Interfaces;
+using EnvironmentsService.Src.Application.DTOs.Get;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AreasController : ControllerBase
+{
+    private readonly IAreaService _areaService;
+
+    public AreasController(IAreaService areaService)
+    {
+        _areaService = areaService;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<AreaDto>>> GetAllAreas()
+    {
+        var areas = await _areaService.GetAllAsync();
+        return Ok(areas);
+    }
+}

--- a/src/WebApi/Controllers/EnvironmentsController.cs
+++ b/src/WebApi/Controllers/EnvironmentsController.cs
@@ -14,7 +14,7 @@ public class EnvironmentsController(IEnvironmentService service) : ControllerBas
     public async Task<IActionResult> GetAvailableEnvironments(
     [FromBody] GetAvailableEnvironmentsRequest request,
     [FromQuery] int page = 1,
-    [FromQuery] int limit = 10)
+    [FromQuery] int limit = 16)
     {
         var result = await _service.GetAvailableEnvironmentsAsync(request, page, limit);
         return Ok(result);

--- a/src/WebApi/Controllers/ServicesController.cs
+++ b/src/WebApi/Controllers/ServicesController.cs
@@ -6,14 +6,14 @@ using EnvironmentsService.Src.Application.DTOs.Get;
 
 [ApiController]
 [Route("api/[controller]")]
-public class AreasController(IAreaService areaService) : ControllerBase
+public class ServicesController(IServiceService serviceService) : ControllerBase
 {
-    private readonly IAreaService _areaService = areaService;
+    private readonly IServiceService _serviceService = serviceService;
 
     [HttpGet]
     public async Task<ActionResult<List<AreaDto>>> GetAllAreas()
     {
-        var areas = await _areaService.GetAllAsync();
-        return Ok(areas);
+        var services = await _serviceService.GetAllAsync();
+        return Ok(services);
     }
 }

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,6 +1,3 @@
-using EnvironmentsService.Src.Application.Commands.Concretes;
-using EnvironmentsService.Src.Application.Commands.Interfaces;
-using EnvironmentsService.Src.Application.DTOs.Get;
 using EnvironmentsService.Src.Application.Interfaces;
 using EnvironmentsService.Src.Application.Mapping;
 using EnvironmentsService.Src.Application.Pipelines;

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -4,9 +4,9 @@ using EnvironmentsService.Src.Application.Pipelines;
 using EnvironmentsService.Src.Application.Services;
 using EnvironmentsService.Src.Application.Strategies.Concretes.GetEnvironments;
 using EnvironmentsService.Src.Application.Strategies.Interfaces;
-using EnvironmentsService.src.Domain.Interfaces;
-using EnvironmentsService.src.Infraestructure.Data;
-using EnvironmentsService.src.Infraestructure.Repositories;
+using EnvironmentsService.Src.Domain.Interfaces;
+using EnvironmentsService.Src.Infraestructure.Data;
+using EnvironmentsService.Src.Infraestructure.Repositories;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -28,8 +28,14 @@ builder.Services.AddControllers();
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+
 builder.Services.AddScoped<IEnvironmentService, EnvironmentService>();
 builder.Services.AddScoped<IEnvironmentRepository, EnvironmentRepository>();
+builder.Services.AddScoped<IAreaService, AreaService>();
+builder.Services.AddScoped<IAreaRepository, AreaRepository>();
+builder.Services.AddScoped<IServiceService, ServiceService>();
+builder.Services.AddScoped<IServiceRepository, ServiceRepository>();
+
 builder.Services.AddScoped<DbContext, AppDbContext>();
 builder.Services.AddScoped<IEnvironmentFilterStrategy, LocationFilterStrategy>();
 builder.Services.AddScoped<IEnvironmentFilterStrategy, EnvironmentTypeFilterStrategy>();


### PR DESCRIPTION
### What I Did

- Implemented `AreaRepository`, `AreaService`, and `AreasController` to retrieve all areas from the database and the same for services
- Added corresponding `IAreaRepository` and `IAreaService` interfaces following Clean Architecture.
- Connected everything through dependency injection.

---

### Why I Did It

- To fulfill the user story requesting that areas and services be fetched from the database and exposed via API.
- This enables the frontend to dynamically load all available areas for environment-related features.

---

### How I Did It

- Queried areas from the database using `DbContext.Set<Area>()` in `AreaRepository` and same for services.
- Used a service layer to handle mapping and business logic.
- Exposed the data through a simple `GET /api/areas` endpoint. and `GET /api/services`
- Maintained Clean Architecture by separating concerns across infrastructure, application, and presentation layers.

---
