### PR TITLE
feature/SPACIO 97/get owner environments

### DIFF
--- a/src/Application/Commands/Concretes/GetOwnerEnvironments.cs
+++ b/src/Application/Commands/Concretes/GetOwnerEnvironments.cs
@@ -1,0 +1,35 @@
+using AutoMapper;
+using EnvironmentsService.Src.Application.Commands.Interfaces;
+using EnvironmentsService.Src.Application.DTOs.Get;
+using EnvironmentsService.Src.Domain.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Commands.Concretes;
+
+public class GetOwnerEnvironments(
+    IEnvironmentRepository repository,
+    IMapper mapper,
+    Guid publicUserId,
+    int page,
+    int limit) : ICommand<PagedResult<GetAllEnvironmentDto>>
+{
+    private readonly IEnvironmentRepository _repository = repository;
+    private readonly IMapper _mapper = mapper;
+    private readonly Guid _userId = publicUserId;
+    private readonly int _page = page;
+    private readonly int _limit = limit;
+
+    public async Task<PagedResult<GetAllEnvironmentDto>> ExecuteAsync()
+    {
+        var (environments, totalItems) = await _repository.GetOwnerEnvironmentsAsync(_userId, _page, _limit);
+        var dtos = _mapper.Map<List<GetAllEnvironmentDto>>(environments);
+
+        return new PagedResult<GetAllEnvironmentDto>
+        {
+            Items = dtos,
+            CurrentPage = _page,
+            TotalPages = (int)Math.Ceiling(totalItems / (double)_limit),
+            Limit = _limit,
+            TotalItems = totalItems,
+        };
+    }
+}

--- a/src/Application/DTOs/Responses/UploadResult.cs
+++ b/src/Application/DTOs/Responses/UploadResult.cs
@@ -1,0 +1,10 @@
+namespace EnvironmentsService.Src.Application.DTOs.Responses;
+
+public class UploadResult
+{
+    required public string FileId { get; set; }
+
+    required public string FileName { get; set; }
+
+    required public string FileUrl { get; set; }
+}

--- a/src/Application/Interfaces/IEnvironmentService.cs
+++ b/src/Application/Interfaces/IEnvironmentService.cs
@@ -8,6 +8,8 @@ public interface IEnvironmentService
 {
     Task<PagedResult<GetAllEnvironmentDto>> GetAvailableEnvironmentsAsync(GetAvailableEnvironmentsRequest request, int page, int limit);
 
+    Task<PagedResult<GetAllEnvironmentDto>> GetOwnerEnvironmentsAsync(Guid publicUserId, int page, int limit);
+
     Task<EnvironmentDto?> GetSingleEnvironmentAsync(Guid publicId);
 
     Task<EnvironmentDto> CreateAsync(CreateEnvironmentDto dto, Guid userId);

--- a/src/Application/Pipelines/EnvironmentFilterPipeline.cs
+++ b/src/Application/Pipelines/EnvironmentFilterPipeline.cs
@@ -3,14 +3,9 @@ using EnvironmentsService.Src.Application.Strategies.Interfaces;
 
 namespace EnvironmentsService.Src.Application.Pipelines;
 
-public class EnvironmentFilterPipeline
+public class EnvironmentFilterPipeline(IEnumerable<IEnvironmentFilterStrategy> strategies)
 {
-    private readonly IEnumerable<IEnvironmentFilterStrategy> _strategies;
-
-    public EnvironmentFilterPipeline(IEnumerable<IEnvironmentFilterStrategy> strategies)
-    {
-        _strategies = strategies;
-    }
+    private readonly IEnumerable<IEnvironmentFilterStrategy> _strategies = strategies;
 
     public IQueryable<Domain.Entities.Environment> ApplyFilters(
         IQueryable<Domain.Entities.Environment> query,

--- a/src/Application/Services/EnvironmentService.cs
+++ b/src/Application/Services/EnvironmentService.cs
@@ -32,6 +32,11 @@ public class EnvironmentService(
         return await command.ExecuteAsync();
     }
 
+    public Task<PagedResult<GetAllEnvironmentDto>> GetOwnerEnvironmentsAsync(Guid publicUserId, int page, int limit)
+    {
+        throw new NotImplementedException();
+    }
+
     public async Task<EnvironmentDto?> GetSingleEnvironmentAsync(Guid publicId)
     {
         var command = new GetSingleEnvironmentCommand(_repository, _mapper, publicId);
@@ -113,14 +118,5 @@ public class EnvironmentService(
         });
 
         return results ?? [];
-    }
-
-    private class UploadResult
-    {
-        required public string FileId { get; set; }
-
-        required public string FileName { get; set; }
-
-        required public string FileUrl { get; set; }
     }
 }

--- a/src/Domain/Interfaces/IEnvironmentRepository.cs
+++ b/src/Domain/Interfaces/IEnvironmentRepository.cs
@@ -8,6 +8,9 @@ public interface IEnvironmentRepository
     Task<(List<Entities.Environment> Environments, int TotalItems)> FilterEnvironmentsAsync(
     GetAvailableEnvironmentsRequest request, int page, int limit);
 
+    Task<(List<Entities.Environment> Environments, int TotalItems)> GetOwnerEnvironmentsAsync(
+    Guid pubUserId, int page, int limit);
+
     Task<Entities.Environment?> GetSingleEnvironment(Guid publicId);
 
     Task AddAsync(Entities.Environment environment);

--- a/src/Infraestructure/Repositories/EnvironmentRepository.cs
+++ b/src/Infraestructure/Repositories/EnvironmentRepository.cs
@@ -12,24 +12,28 @@ public class EnvironmentRepository(DbContext context, EnvironmentFilterPipeline 
     private readonly EnvironmentFilterPipeline _pipeline = pipeline;
 
     public async Task<(List<Domain.Entities.Environment> Environments, int TotalItems)> FilterEnvironmentsAsync(
-        GetAvailableEnvironmentsRequest request, int page, int limit)
+    GetAvailableEnvironmentsRequest request, int page, int limit)
     {
-        var baseQuery = _context.Set<Domain.Entities.Environment>()
-            .Include(e => e.Type)
-            .Include(e => e.PricingPolicies)
-            .Include(e => e.Photos)
-            .Include(e => e.EnvironmentServices).ThenInclude(es => es.Service)
-            .Include(e => e.EnvironmentAreas).ThenInclude(ea => ea.Area)
-            .Include(e => e.NonAvailabilities)
-            .Where(e => e.Deleted == false)
-            .Where(e => e.Hidden == false)
-            .AsQueryable();
-
+        var baseQuery = GetBaseEnvironmentQuery();
         var filteredQuery = _pipeline.ApplyFilters(baseQuery, request);
 
         var totalItems = await filteredQuery.CountAsync();
-
         var environments = await filteredQuery
+            .Skip((page - 1) * limit)
+            .Take(limit)
+            .ToListAsync();
+
+        return (environments, totalItems);
+    }
+
+    public async Task<(List<Domain.Entities.Environment> Environments, int TotalItems)> GetOwnerEnvironmentsAsync(
+    Guid pubUserId, int page, int limit)
+    {
+        var baseQuery = GetBaseEnvironmentQuery()
+            .Where(e => e.OwnerId == pubUserId);
+
+        var totalItems = await baseQuery.CountAsync();
+        var environments = await baseQuery
             .Skip((page - 1) * limit)
             .Take(limit)
             .ToListAsync();
@@ -39,17 +43,7 @@ public class EnvironmentRepository(DbContext context, EnvironmentFilterPipeline 
 
     public async Task<Domain.Entities.Environment?> GetSingleEnvironment(Guid publicId)
     {
-        return await _context.Set<Domain.Entities.Environment>()
-            .Include(e => e.Type)
-            .Include(e => e.PricingPolicies)
-            .Include(e => e.Photos)
-            .Include(e => e.DiscountPolicies)
-            .Include(e => e.WeeklySchedules)
-            .Include(e => e.SpecialAvailabilities)
-            .Include(e => e.EnvironmentServices).ThenInclude(es => es.Service)
-            .Include(e => e.EnvironmentAreas).ThenInclude(ea => ea.Area)
-            .Include(e => e.NonAvailabilities)
-            .Where(e => e.Deleted == false && e.Hidden == false)
+        return await GetBaseEnvironmentQuery()
             .FirstOrDefaultAsync(e => e.PublicId == publicId);
     }
 
@@ -67,5 +61,18 @@ public class EnvironmentRepository(DbContext context, EnvironmentFilterPipeline 
     {
         await _context.Set<EnvironmentPhoto>().AddAsync(image);
         await _context.SaveChangesAsync();
+    }
+
+    private IQueryable<Domain.Entities.Environment> GetBaseEnvironmentQuery()
+    {
+        return _context.Set<Domain.Entities.Environment>()
+            .Include(e => e.Type)
+            .Include(e => e.PricingPolicies)
+            .Include(e => e.Photos)
+            .Include(e => e.EnvironmentServices).ThenInclude(es => es.Service)
+            .Include(e => e.EnvironmentAreas).ThenInclude(ea => ea.Area)
+            .Include(e => e.NonAvailabilities)
+            .Where(e => !e.Deleted && !e.Hidden)
+            .AsQueryable();
     }
 }

--- a/src/WebApi/Controllers/EnvironmentsController.cs
+++ b/src/WebApi/Controllers/EnvironmentsController.cs
@@ -21,6 +21,21 @@ public class EnvironmentsController(IEnvironmentService service) : ControllerBas
         return Ok(result);
     }
 
+    [HttpPost("owner")]
+    public async Task<IActionResult> GetOwnerEnvironments(
+        [FromQuery] int page = 1,
+        [FromQuery] int limit = 16)
+    {
+        var publicIdClaim = Request.Cookies["publicId"];
+        if (publicIdClaim == null || !Guid.TryParse(publicIdClaim, out var userPublicId))
+        {
+            return Unauthorized("Invalid or missing user public_id" + publicIdClaim);
+        }
+
+        var result = await _service.GetOwnerEnvironmentsAsync(userPublicId, page, limit);
+        return Ok(result);
+    }
+
     [HttpGet("single")]
     public async Task<IActionResult> GetSingleEnvironment([FromQuery] Guid publicId)
     {


### PR DESCRIPTION
### What I did:
Implemented an endpoint to retrieve all environments created by a specific owner, with pagination.

---

### How I did it:

Created a query that includes related entities (Type, Photos, Services, Areas, etc.).

Applied filters for OwnerId, excluding deleted and hidden environments.

Added pagination with Skip and Take.

Returned the total item count and current page results.

---

### Why I did it:
To allow owners to view and manage their environments from their dashboard.