### PR TITLE
Feature/spacio 85/update booking request status

### DIFF
--- a/src/Application/Commands/Concretes/UpdateReservationStatusCommand.cs
+++ b/src/Application/Commands/Concretes/UpdateReservationStatusCommand.cs
@@ -1,0 +1,52 @@
+using AutoMapper;
+using EnvironmentsService.Src.Application.DTOs.Responses;
+using EnvironmentsService.Src.Domain.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Commands.Concretes;
+
+public class UpdateReservationStatusCommand(
+    Guid reservationPublicId,
+    string newStatus,
+    IReservationRepository resRepo,
+    IMapper mapper)
+{
+    private readonly Guid _reservationPublicId = reservationPublicId;
+    private readonly string _newStatus = newStatus.ToLower();
+    private readonly IReservationRepository _resRepo = resRepo;
+    private readonly IMapper _mapper = mapper;
+
+    public async Task<ReservationResponse> ExecuteAsync()
+    {
+        var reservation = await _resRepo.GetByPublicIdAsync(_reservationPublicId)
+            ?? throw new Exception("La reserva no existe.");
+
+        if (reservation.Status == "rejected")
+        {
+            throw new Exception("No se puede cambiar el estado de una reserva rechazada.");
+        }
+
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var latestEnd = reservation.TimeRanges.Max(r => r.EndDate);
+        if (latestEnd < now)
+        {
+            throw new Exception("No se puede cambiar el estado de una reserva ya pasada.");
+        }
+
+        if (_newStatus == "confirmed")
+        {
+            bool overlaps = await _resRepo.ExistsOverlappingConfirmedAsync(
+                reservation.EnvironmentId,
+                reservation.Id,
+                reservation.TimeRanges);
+
+            if (overlaps)
+            {
+                throw new Exception("Ya existe una reserva confirmada para este periodo.");
+            }
+        }
+
+        reservation.Status = _newStatus;
+        await _resRepo.SaveChangesAsync();
+        return _mapper.Map<ReservationResponse>(reservation);
+    }
+}

--- a/src/Application/DTOs/Patch/UpdateReservationStatusDto.cs
+++ b/src/Application/DTOs/Patch/UpdateReservationStatusDto.cs
@@ -1,0 +1,6 @@
+namespace EnvironmentsService.src.Application.DTOs.Patch;
+
+public class UpdateReservationStatusDto
+{
+    public string Status { get; set; } = null!;
+}

--- a/src/Application/Interfaces/IReservationService.cs
+++ b/src/Application/Interfaces/IReservationService.cs
@@ -10,4 +10,6 @@ public interface IReservationService
     Task<List<ReservationResponse>> GetByUserAsync(Guid userId, string? status, int page, int limit);
 
     Task<ReservationResponse?> GetByPublicIdAsync(Guid publicId);
+
+    Task<ReservationResponse> UpdateStatusAsync(Guid reservationPublicId, string newStatus);
 }

--- a/src/Application/Services/ReservationService.cs
+++ b/src/Application/Services/ReservationService.cs
@@ -39,4 +39,10 @@ public class ReservationService(
         var reservation = await _resRepo.GetByPublicIdAsync(publicId);
         return reservation == null ? null : _mapper.Map<ReservationResponse>(reservation);
     }
+
+    public async Task<ReservationResponse> UpdateStatusAsync(Guid reservationPublicId, string newStatus)
+    {
+        var command = new UpdateReservationStatusCommand(reservationPublicId, newStatus, _resRepo, _mapper);
+        return await command.ExecuteAsync();
+    }
 }

--- a/src/Domain/Interfaces/IReservationRepository.cs
+++ b/src/Domain/Interfaces/IReservationRepository.cs
@@ -18,4 +18,9 @@ public interface IReservationRepository
     Task<List<Reservation>> GetUserReservationsAsync(Guid userId, string status, int page, int limit);
 
     Task<Reservation?> GetByPublicIdAsync(Guid publicId);
+
+    Task<bool> ExistsOverlappingConfirmedAsync(
+        Guid environmentId,
+        Guid currentReservationId,
+        ICollection<ReservationTimeRange> timeRanges);
 }

--- a/src/Infraestructure/Repositories/ReservationRepository.cs
+++ b/src/Infraestructure/Repositories/ReservationRepository.cs
@@ -88,9 +88,6 @@ public class ReservationRepository(DbContext context) : IReservationRepository
             conf.TimeRanges.Any(cRange =>
                 timeRanges.Any(newRange =>
                     newRange.StartDate < cRange.EndDate &&
-                    newRange.EndDate > cRange.StartDate
-                )
-            )
-        );
+                    newRange.EndDate > cRange.StartDate)));
     }
 }

--- a/src/Infraestructure/Repositories/ReservationRepository.cs
+++ b/src/Infraestructure/Repositories/ReservationRepository.cs
@@ -71,4 +71,26 @@ public class ReservationRepository(DbContext context) : IReservationRepository
                 .ThenInclude(e => e.Photos)
             .FirstOrDefaultAsync(r => r.PublicId == publicId);
     }
+
+    public async Task<bool> ExistsOverlappingConfirmedAsync(
+        Guid environmentId,
+        Guid currentReservationId,
+        ICollection<ReservationTimeRange> timeRanges)
+    {
+        var confirmed = await _context.Set<Reservation>()
+            .Include(r => r.TimeRanges)
+            .Where(r => r.EnvironmentId == environmentId &&
+                        r.Status == "confirmed" &&
+                        r.Id != currentReservationId)
+            .ToListAsync();
+
+        return confirmed.Any(conf =>
+            conf.TimeRanges.Any(cRange =>
+                timeRanges.Any(newRange =>
+                    newRange.StartDate < cRange.EndDate &&
+                    newRange.EndDate > cRange.StartDate
+                )
+            )
+        );
+    }
 }

--- a/src/WebApi/Controllers/ReservationsController.cs
+++ b/src/WebApi/Controllers/ReservationsController.cs
@@ -1,4 +1,5 @@
 using EnvironmentsService.Src.Application.DTOs.Create;
+using EnvironmentsService.src.Application.DTOs.Patch;
 using EnvironmentsService.Src.Application.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -60,6 +61,20 @@ public class ReservationsController(IReservationService service) : ControllerBas
             }
 
             return Ok(reservation);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { mensaje = ex.Message });
+        }
+    }
+
+    [HttpPatch("{publicId:guid}/status")]
+    public async Task<IActionResult> UpdateStatus(Guid publicId, [FromBody] UpdateReservationStatusDto request)
+    {
+        try
+        {
+            var updated = await _service.UpdateStatusAsync(publicId, request.Status);
+            return Ok(updated);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION

**What I did:**

* Implemented the ability to update the status of a reservation via `UpdateStatusAsync` in `ReservationService`.
* Refactored logic into a new command: `UpdateReservationStatusCommand` for better separation of concerns.
* Added validation to prevent status changes on:

  * Rejected reservations.
  * Past reservations (based on max end time).
  * Conflicting time ranges when confirming a reservation.
* Ensured only allowed transitions are permitted.
* Connected everything to the existing ReservationRepository and AutoMapper layers.

**How I did it:**

* Created a new command class `UpdateReservationStatusCommand` following the Command pattern.
* Injected repository and mapper dependencies to encapsulate all logic in the command.
* Updated `ReservationService` to delegate status updates to the new command.
* Preserved clean architecture boundaries between Application and Domain layers.

**Why I did it:**

* To allow owners or admins to manage reservation statuses (approve, reject, cancel) via a consistent and safe mechanism.
* To ensure data integrity and prevent overlapping confirmed bookings.
* To align backend logic with upcoming frontend functionality for reservation management.
