### PR TITLE
Feature/spacio 90/bookings calendar

### DIFF
--- a/src/Application/Commands/Concretes/CreateReservationCommand.cs
+++ b/src/Application/Commands/Concretes/CreateReservationCommand.cs
@@ -121,7 +121,7 @@ public class CreateReservationCommand(
             OwnerId = environment.OwnerId,
             RenterId = request.RenterId,
             IsInstant = environment.InstantBooking,
-            Status = environment.InstantBooking ? "confirmed" : "pending",
+            Status = environment.InstantBooking ? "paid" : "pending",
             CreatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             Currency = request.Currency,
             TotalPrice = request.TotalPrice,

--- a/src/Application/DTOs/Create/BlockAvailabilityRequest.cs
+++ b/src/Application/DTOs/Create/BlockAvailabilityRequest.cs
@@ -1,0 +1,8 @@
+namespace EnvironmentsService.src.Application.DTOs.Create;
+
+public class BlockAvailabilityRequest
+{
+    public Guid EnvironmentId { get; set; }
+
+    public long Date { get; set; }
+}

--- a/src/Application/DTOs/Create/BlockAvailabilityRequest.cs
+++ b/src/Application/DTOs/Create/BlockAvailabilityRequest.cs
@@ -4,5 +4,7 @@ public class BlockAvailabilityRequest
 {
     public Guid EnvironmentId { get; set; }
 
-    public long Date { get; set; }
+    public long StartDate { get; set; }
+
+    public long EndDate { get; set; }
 }

--- a/src/Application/DTOs/Responses/ReservationResponseDto.cs
+++ b/src/Application/DTOs/Responses/ReservationResponseDto.cs
@@ -10,9 +10,13 @@ public class ReservationResponse
 
     public string EnvironmentTitle { get; set; } = string.Empty;
 
+    public string RentalUnit { get; set; } = string.Empty;
+
     public string? EnvironmentPhotoUrl { get; set; }
 
     public Guid RenterId { get; set; }
+
+    public Guid OwnerId { get; set; }
 
     public List<TimeRangeDto> TimeRanges { get; set; } = [];
 

--- a/src/Application/Interfaces/IAvailabilityService.cs
+++ b/src/Application/Interfaces/IAvailabilityService.cs
@@ -8,4 +8,6 @@ public interface IAvailabilityService
     Task<List<TimeRange>> GetUnavailableTimeSlotsAsync(Guid envId, long start, long end);
 
     Task BlockDateAsync(BlockAvailabilityRequest request, Guid ownerId);
+
+    Task<List<OwnerBlockedAvailabilityDto>> GetOwnerBlockedAsync(Guid ownerId);
 }

--- a/src/Application/Interfaces/IAvailabilityService.cs
+++ b/src/Application/Interfaces/IAvailabilityService.cs
@@ -1,3 +1,4 @@
+using EnvironmentsService.src.Application.DTOs.Create;
 using EnvironmentsService.Src.Application.DTOs.Get;
 
 namespace EnvironmentsService.Src.Application.Interfaces;
@@ -5,4 +6,6 @@ namespace EnvironmentsService.Src.Application.Interfaces;
 public interface IAvailabilityService
 {
     Task<List<TimeRange>> GetUnavailableTimeSlotsAsync(Guid envId, long start, long end);
+
+    Task BlockDateAsync(BlockAvailabilityRequest request, Guid ownerId);
 }

--- a/src/Application/Interfaces/IReservationService.cs
+++ b/src/Application/Interfaces/IReservationService.cs
@@ -1,4 +1,5 @@
 using EnvironmentsService.Src.Application.DTOs.Create;
+using EnvironmentsService.Src.Application.DTOs.Get;
 using EnvironmentsService.Src.Application.DTOs.Responses;
 
 namespace EnvironmentsService.Src.Application.Interfaces;
@@ -7,9 +8,13 @@ public interface IReservationService
 {
     Task<ReservationResponse> CreateAsync(CreateReservationRequest request, Guid renterId);
 
-    Task<List<ReservationResponse>> GetByUserAsync(Guid userId, string? status, int page, int limit);
+    Task<PagedResult<ReservationResponse>> GetByUserAsync(Guid userId, string? status, int page, int limit);
 
     Task<ReservationResponse?> GetByPublicIdAsync(Guid publicId);
 
     Task<ReservationResponse> UpdateStatusAsync(Guid reservationPublicId, string newStatus);
+
+    Task<List<ReservationResponse>> GetConflictingReservationsAsync(Guid environmentId, long start, long end);
+
+    Task<List<ReservationResponse>> GetByOwnerAndDayAsync(Guid ownerId, long timestamp);
 }

--- a/src/Application/Mapping/EnvironmentProfile.cs
+++ b/src/Application/Mapping/EnvironmentProfile.cs
@@ -56,6 +56,8 @@ public class EnvironmentProfile : Profile
         CreateMap<ReservationTimeRange, TimeRangeDto>().ReverseMap();
         CreateMap<Reservation, ReservationResponse>()
             .ForMember(dest => dest.EnvironmentTitle, opt => opt.MapFrom(src => src.Environment.Title))
+            .ForMember(dest => dest.OwnerId, opt => opt.MapFrom(src => src.Environment.OwnerId))
+            .ForMember(dest => dest.RentalUnit, opt => opt.MapFrom(src => src.Environment.RentalUnit))
             .ForMember(dest => dest.EnvironmentPhotoUrl, opt => opt.MapFrom(src =>
                 src.Environment.Photos.OrderBy(p => p.Order).Select(p => p.Url).FirstOrDefault()))
             .ForMember(dest => dest.TimeRanges, opt => opt.MapFrom(src => src.TimeRanges))

--- a/src/Application/OwnerBlockedAvailabilityDto.cs
+++ b/src/Application/OwnerBlockedAvailabilityDto.cs
@@ -1,0 +1,12 @@
+namespace EnvironmentsService.Src.Application;
+
+public class OwnerBlockedAvailabilityDto
+{
+    public string EnvironmentTitle { get; set; } = string.Empty;
+
+    public string? EnvironmentPhotoUrl { get; set; }
+
+    public long StartDate { get; set; }
+
+    public long EndDate { get; set; }
+}

--- a/src/Application/Services/AvailabilityService.cs
+++ b/src/Application/Services/AvailabilityService.cs
@@ -43,18 +43,32 @@ public class AvailabilityService(
             throw new Exception("No tienes permiso para modificar este ambiente");
         }
 
-        var date = DateTimeOffset.FromUnixTimeMilliseconds(request.Date).UtcDateTime.Date;
-
-        var start = new DateTimeOffset(date).ToUnixTimeMilliseconds();
-        var end = new DateTimeOffset(date.AddDays(1).AddMinutes(-1)).ToUnixTimeMilliseconds(); // 23:59
+        if (request.StartDate >= request.EndDate)
+        {
+            throw new Exception("La hora de inicio debe ser menor que la hora de fin");
+        }
 
         await _availRepo.AddAsync(new NonAvailability
         {
             EnvironmentId = request.EnvironmentId,
-            StartDate = start,
-            EndDate = end,
+            StartDate = request.StartDate,
+            EndDate = request.EndDate,
+            Type = "OwnerBlocked",
         });
 
         await _availRepo.SaveChangesAsync();
+    }
+
+    public async Task<List<OwnerBlockedAvailabilityDto>> GetOwnerBlockedAsync(Guid ownerId)
+    {
+        var blocked = await _availRepo.GetOwnerBlockedByOwnerIdAsync(ownerId);
+
+        return [.. blocked.Select(n => new OwnerBlockedAvailabilityDto
+        {
+            EnvironmentTitle = n.Environment.Title,
+            EnvironmentPhotoUrl = n.Environment.Photos.OrderBy(p => p.Order).FirstOrDefault()?.Url,
+            StartDate = n.StartDate,
+            EndDate = n.EndDate,
+        })];
     }
 }

--- a/src/Application/Services/AvailabilityService.cs
+++ b/src/Application/Services/AvailabilityService.cs
@@ -1,20 +1,25 @@
+using EnvironmentsService.src.Application.DTOs.Create;
 using EnvironmentsService.Src.Application.DTOs.Get;
 using EnvironmentsService.Src.Application.Interfaces;
+using EnvironmentsService.Src.Domain.Entities;
 using EnvironmentsService.Src.Domain.Interfaces;
 
 namespace EnvironmentsService.Src.Application.Services;
 
-public class AvailabilityService(IAvailabilityRepository availabilityRepo) : IAvailabilityService
+public class AvailabilityService(
+    IEnvironmentRepository environmentRepo,
+    IAvailabilityRepository availabilityRepo) : IAvailabilityService
 {
-    private readonly IAvailabilityRepository _availabilityRepo = availabilityRepo;
+    private readonly IEnvironmentRepository _envRepo = environmentRepo;
+    private readonly IAvailabilityRepository _availRepo = availabilityRepo;
 
     public async Task<List<TimeRange>> GetUnavailableTimeSlotsAsync(Guid envId, long startTimestamp, long endTimestamp)
     {
         var start = DateTimeOffset.FromUnixTimeMilliseconds(startTimestamp).UtcDateTime;
         var end = DateTimeOffset.FromUnixTimeMilliseconds(endTimestamp).UtcDateTime;
 
-        var nonAvailabilities = await _availabilityRepo.GetNonAvailabilitiesAsync(envId, start, end);
-        var reservations = await _availabilityRepo.GetReservationsAsync(envId, start, end);
+        var nonAvailabilities = await _availRepo.GetNonAvailabilitiesAsync(envId, start, end);
+        var reservations = await _availRepo.GetReservationsAsync(envId, start, end);
 
         var allRanges = new List<TimeRange>();
 
@@ -26,5 +31,30 @@ public class AvailabilityService(IAvailabilityRepository availabilityRepo) : IAv
             .Select(tr => new TimeRange(tr.StartDate, tr.EndDate)));
 
         return allRanges;
+    }
+
+    public async Task BlockDateAsync(BlockAvailabilityRequest request, Guid ownerId)
+    {
+        var environment = await _envRepo.GetSingleEnvironment(request.EnvironmentId)
+            ?? throw new Exception("El ambiente no existe");
+
+        if (environment.OwnerId != ownerId)
+        {
+            throw new Exception("No tienes permiso para modificar este ambiente");
+        }
+
+        var date = DateTimeOffset.FromUnixTimeMilliseconds(request.Date).UtcDateTime.Date;
+
+        var start = new DateTimeOffset(date).ToUnixTimeMilliseconds();
+        var end = new DateTimeOffset(date.AddDays(1).AddMinutes(-1)).ToUnixTimeMilliseconds(); // 23:59
+
+        await _availRepo.AddAsync(new NonAvailability
+        {
+            EnvironmentId = request.EnvironmentId,
+            StartDate = start,
+            EndDate = end,
+        });
+
+        await _availRepo.SaveChangesAsync();
     }
 }

--- a/src/Application/Services/ReservationService.cs
+++ b/src/Application/Services/ReservationService.cs
@@ -3,6 +3,7 @@ namespace EnvironmentsService.Src.Application.Services;
 using AutoMapper;
 using EnvironmentsService.Src.Application.Commands.Concretes;
 using EnvironmentsService.Src.Application.DTOs.Create;
+using EnvironmentsService.Src.Application.DTOs.Get;
 using EnvironmentsService.Src.Application.DTOs.Responses;
 using EnvironmentsService.Src.Application.Interfaces;
 using EnvironmentsService.Src.Domain.Interfaces;
@@ -25,13 +26,21 @@ public class ReservationService(
         return await command.ExecuteAsync();
     }
 
-    public async Task<List<ReservationResponse>> GetByUserAsync(Guid userId, string? status, int page, int limit)
+    public async Task<PagedResult<ReservationResponse>> GetByUserAsync(Guid userId, string? status, int page, int limit)
     {
         var validStatuses = new[] { "pending", "confirmed", "rejected", "cancelled", "paid" };
         var normalizedStatus = validStatuses.Contains(status?.ToLower()) ? status!.ToLower() : "confirmed";
 
-        var reservations = await _resRepo.GetUserReservationsAsync(userId, normalizedStatus, page, limit);
-        return _mapper.Map<List<ReservationResponse>>(reservations);
+        var (reservations, totalItems) = await _resRepo.GetUserReservationsPaginatedAsync(userId, normalizedStatus, page, limit);
+
+        return new PagedResult<ReservationResponse>
+        {
+            Items = _mapper.Map<List<ReservationResponse>>(reservations),
+            CurrentPage = page,
+            Limit = limit,
+            TotalItems = totalItems,
+            TotalPages = (int)Math.Ceiling((double)totalItems / limit),
+        };
     }
 
     public async Task<ReservationResponse?> GetByPublicIdAsync(Guid publicId)
@@ -44,5 +53,17 @@ public class ReservationService(
     {
         var command = new UpdateReservationStatusCommand(reservationPublicId, newStatus, _resRepo, _mapper);
         return await command.ExecuteAsync();
+    }
+
+    public async Task<List<ReservationResponse>> GetConflictingReservationsAsync(Guid environmentId, long start, long end)
+    {
+        var conflicts = await _resRepo.GetConflictsAsync(environmentId, start, end);
+        return _mapper.Map<List<ReservationResponse>>(conflicts);
+    }
+
+    public async Task<List<ReservationResponse>> GetByOwnerAndDayAsync(Guid ownerId, long timestamp)
+    {
+        var reservations = await _resRepo.GetByOwnerAndDayAsync(ownerId, timestamp);
+        return _mapper.Map<List<ReservationResponse>>(reservations);
     }
 }

--- a/src/Application/Strategies/Concretes/GetEnvironments/DateAvailabilityFilterStrategy.cs
+++ b/src/Application/Strategies/Concretes/GetEnvironments/DateAvailabilityFilterStrategy.cs
@@ -11,8 +11,29 @@ public class DateAvailabilityFilterStrategy : IEnvironmentFilterStrategy
     {
         if (request.StartDate.HasValue && request.EndDate.HasValue)
         {
-            query = query.Where(e => !e.NonAvailabilities.Any(n =>
-                n.StartDate <= request.StartDate && n.EndDate >= request.EndDate));
+            var start = DateTimeOffset.FromUnixTimeMilliseconds(request.StartDate.Value).UtcDateTime;
+            var end = DateTimeOffset.FromUnixTimeMilliseconds(request.EndDate.Value).UtcDateTime;
+
+            query = query.Where(e =>
+                !e.NonAvailabilities.Any(n =>
+                    n.StartDate < request.EndDate && n.EndDate > request.StartDate));
+
+            var dates = Enumerable.Range(0, (end.Date - start.Date).Days + 1)
+                .Select(offset => start.Date.AddDays(offset))
+                .ToList();
+
+            foreach (var date in dates)
+            {
+                var dow = (int)date.DayOfWeek;
+                var startMinutes = date == start.Date ? (start.Hour * 60) + start.Minute : 0;
+                var endMinutes = date == end.Date ? (end.Hour * 60) + end.Minute : 1440;
+
+                query = query.Where(e =>
+                    e.WeeklySchedules.Any(ws =>
+                        ws.DayOfWeek == dow &&
+                        ws.StartTime <= startMinutes &&
+                        ws.EndTime >= endMinutes));
+            }
         }
 
         return query;

--- a/src/Application/Strategies/Interfaces/IEnvironmentFilterStrategy.cs
+++ b/src/Application/Strategies/Interfaces/IEnvironmentFilterStrategy.cs
@@ -4,7 +4,7 @@ namespace EnvironmentsService.Src.Application.Strategies.Interfaces;
 
 public interface IEnvironmentFilterStrategy
 {
-    IQueryable<Src.Domain.Entities.Environment> Apply(
-            IQueryable<Src.Domain.Entities.Environment> query,
+    IQueryable<Domain.Entities.Environment> Apply(
+            IQueryable<Domain.Entities.Environment> query,
             GetAvailableEnvironmentsRequest request);
 }

--- a/src/Domain/Interfaces/IAvailabilityRepository.cs
+++ b/src/Domain/Interfaces/IAvailabilityRepository.cs
@@ -8,4 +8,8 @@ public interface IAvailabilityRepository
     Task<IEnumerable<NonAvailability>> GetNonAvailabilitiesAsync(Guid environmentId, DateTime start, DateTime end);
 
     Task<IEnumerable<Reservation>> GetReservationsAsync(Guid environmentId, DateTime start, DateTime end);
+
+    Task AddAsync(NonAvailability availability);
+
+    Task SaveChangesAsync();
 }

--- a/src/Domain/Interfaces/IAvailabilityRepository.cs
+++ b/src/Domain/Interfaces/IAvailabilityRepository.cs
@@ -9,6 +9,8 @@ public interface IAvailabilityRepository
 
     Task<IEnumerable<Reservation>> GetReservationsAsync(Guid environmentId, DateTime start, DateTime end);
 
+    Task<List<NonAvailability>> GetOwnerBlockedByOwnerIdAsync(Guid ownerId);
+
     Task AddAsync(NonAvailability availability);
 
     Task SaveChangesAsync();

--- a/src/Domain/Interfaces/IReservationRepository.cs
+++ b/src/Domain/Interfaces/IReservationRepository.cs
@@ -15,7 +15,7 @@ public interface IReservationRepository
 
     Task SaveChangesAsync();
 
-    Task<List<Reservation>> GetUserReservationsAsync(Guid userId, string status, int page, int limit);
+    Task<(List<Reservation>, int)> GetUserReservationsPaginatedAsync(Guid userId, string status, int page, int limit);
 
     Task<Reservation?> GetByPublicIdAsync(Guid publicId);
 
@@ -23,4 +23,8 @@ public interface IReservationRepository
         Guid environmentId,
         Guid currentReservationId,
         ICollection<ReservationTimeRange> timeRanges);
+
+    Task<List<Reservation>> GetConflictsAsync(Guid environmentId, long start, long end);
+
+    Task<List<Reservation>> GetByOwnerAndDayAsync(Guid ownerId, long timestamp);
 }

--- a/src/Infraestructure/Repositories/AvailabilityRepository.cs
+++ b/src/Infraestructure/Repositories/AvailabilityRepository.cs
@@ -38,4 +38,14 @@ public class AvailabilityRepository(AppDbContext context) : IAvailabilityReposit
                             tr.EndDate > startUnix))
             .ToListAsync();
     }
+
+    public async Task AddAsync(NonAvailability availability)
+    {
+        await _context.NonAvailabilities.AddAsync(availability);
+    }
+
+    public async Task SaveChangesAsync()
+    {
+        await _context.SaveChangesAsync();
+    }
 }

--- a/src/Infraestructure/Repositories/AvailabilityRepository.cs
+++ b/src/Infraestructure/Repositories/AvailabilityRepository.cs
@@ -39,6 +39,15 @@ public class AvailabilityRepository(AppDbContext context) : IAvailabilityReposit
             .ToListAsync();
     }
 
+    public async Task<List<NonAvailability>> GetOwnerBlockedByOwnerIdAsync(Guid ownerId)
+    {
+        return await _context.NonAvailabilities
+            .Include(n => n.Environment)
+            .ThenInclude(e => e.Photos)
+            .Where(n => n.Type == "OwnerBlocked" && n.Environment.OwnerId == ownerId)
+            .ToListAsync();
+    }
+
     public async Task AddAsync(NonAvailability availability)
     {
         await _context.NonAvailabilities.AddAsync(availability);

--- a/src/Infraestructure/Repositories/ReservationRepository.cs
+++ b/src/Infraestructure/Repositories/ReservationRepository.cs
@@ -48,22 +48,6 @@ public class ReservationRepository(DbContext context) : IReservationRepository
             .ToListAsync();
     }
 
-    public async Task<List<Reservation>> GetUserReservationsAsync(Guid userId, string status, int page, int limit)
-    {
-        var query = _context.Set<Reservation>()
-            .Where(r => r.RenterId == userId && r.Status.ToLower() == status.ToLower())
-            .Include(r => r.Environment)
-                .ThenInclude(e => e.Photos)
-            .Include(r => r.TimeRanges)
-            .AsQueryable();
-
-        return await query
-            .OrderBy(r => r.TimeRanges.Min(tr => tr.StartDate))
-            .Skip((page - 1) * limit)
-            .Take(limit)
-            .ToListAsync();
-    }
-
     public async Task<Reservation?> GetByPublicIdAsync(Guid publicId)
     {
         return await _context.Set<Reservation>()
@@ -89,5 +73,53 @@ public class ReservationRepository(DbContext context) : IReservationRepository
                 timeRanges.Any(newRange =>
                     newRange.StartDate < cRange.EndDate &&
                     newRange.EndDate > cRange.StartDate)));
+    }
+
+    public async Task<(List<Reservation>, int)> GetUserReservationsPaginatedAsync(Guid userId, string status, int page, int limit)
+    {
+        var query = _context.Set<Reservation>()
+            .Include(r => r.Environment)
+                .ThenInclude(e => e.Photos)
+            .Where(r => (r.RenterId == userId || r.OwnerId == userId) && r.Status == status);
+
+        var totalItems = await query.CountAsync();
+        var reservations = await query
+            .OrderByDescending(r => r.CreatedAt)
+            .Skip((page - 1) * limit)
+            .Take(limit)
+            .ToListAsync();
+
+        return (reservations, totalItems);
+    }
+
+    public async Task<List<Reservation>> GetConflictsAsync(Guid environmentId, long start, long end)
+    {
+        return await _context.Set<Reservation>()
+            .Where(r => r.EnvironmentId == environmentId)
+            .Where(r => r.Status == "pending" || r.Status == "confirmed")
+            .Where(r =>
+                r.TimeRanges.Any(tr =>
+                    start < tr.EndDate &&
+                    end > tr.StartDate))
+            .Include(r => r.Environment)
+            .Include(r => r.TimeRanges)
+            .ToListAsync();
+    }
+
+    public async Task<List<Reservation>> GetByOwnerAndDayAsync(Guid ownerId, long timestamp)
+    {
+        var startOfDay = DateTimeOffset.FromUnixTimeMilliseconds(timestamp).UtcDateTime.Date;
+        var endOfDay = startOfDay.AddDays(1).AddTicks(-1);
+        var startUnix = new DateTimeOffset(startOfDay).ToUnixTimeMilliseconds();
+        var endUnix = new DateTimeOffset(endOfDay).ToUnixTimeMilliseconds();
+
+        var excludedStatuses = new[] { "rejected", "cancelled" };
+
+        return await _context.Set<Reservation>()
+            .Where(r => r.OwnerId == ownerId && !excludedStatuses.Contains(r.Status))
+            .Where(r => r.TimeRanges.Any(tr => tr.StartDate < endUnix && tr.EndDate > startUnix))
+            .Include(r => r.Environment)
+            .ThenInclude(e => e.Photos)
+            .ToListAsync();
     }
 }

--- a/src/WebApi/Controllers/AvailabilityController.cs
+++ b/src/WebApi/Controllers/AvailabilityController.cs
@@ -37,4 +37,18 @@ public class AvailabilityController(IAvailabilityService service) : ControllerBa
             return BadRequest(new { error = ex.Message });
         }
     }
+
+    [HttpGet("owner-blocked")]
+    public async Task<IActionResult> GetOwnerBlocked()
+    {
+        var publicIdClaim = Request.Cookies["publicId"];
+
+        if (publicIdClaim == null || !Guid.TryParse(publicIdClaim, out var ownerId))
+        {
+            return Unauthorized("Invalid or missing user public_id");
+        }
+
+        var result = await _service.GetOwnerBlockedAsync(ownerId);
+        return Ok(result);
+    }
 }

--- a/src/WebApi/Controllers/AvailabilityController.cs
+++ b/src/WebApi/Controllers/AvailabilityController.cs
@@ -1,3 +1,4 @@
+using EnvironmentsService.src.Application.DTOs.Create;
 using EnvironmentsService.Src.Application.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -14,5 +15,26 @@ public class AvailabilityController(IAvailabilityService service) : ControllerBa
     {
         var result = await _service.GetUnavailableTimeSlotsAsync(envId, start, end);
         return Ok(result);
+    }
+
+    [HttpPost("block")]
+    public async Task<IActionResult> BlockDate([FromBody] BlockAvailabilityRequest request)
+    {
+        var publicIdClaim = Request.Cookies["publicId"];
+
+        if (publicIdClaim == null || !Guid.TryParse(publicIdClaim, out var ownerId))
+        {
+            return Unauthorized("Invalid or missing user public_id");
+        }
+
+        try
+        {
+            await _service.BlockDateAsync(request, ownerId);
+            return Ok(new { message = "Fecha bloqueada exitosamente" });
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
     }
 }

--- a/src/WebApi/Controllers/ReservationsController.cs
+++ b/src/WebApi/Controllers/ReservationsController.cs
@@ -81,4 +81,34 @@ public class ReservationsController(IReservationService service) : ControllerBas
             return BadRequest(new { mensaje = ex.Message });
         }
     }
+
+    [HttpGet("conflicts")]
+    public async Task<IActionResult> GetConflictingReservations(
+    [FromQuery] Guid environmentId,
+    [FromQuery] long start,
+    [FromQuery] long end)
+    {
+        var conflicts = await _service.GetConflictingReservationsAsync(environmentId, start, end);
+        return Ok(conflicts);
+    }
+
+    [HttpGet("day")]
+    public async Task<IActionResult> GetReservationsByDay([FromQuery] long timestamp)
+    {
+        var publicIdClaim = Request.Cookies["publicId"];
+        if (publicIdClaim == null || !Guid.TryParse(publicIdClaim, out var userPublicId))
+        {
+            return Unauthorized("Invalid or missing user public_id");
+        }
+
+        try
+        {
+            var reservations = await _service.GetByOwnerAndDayAsync(userPublicId, timestamp);
+            return Ok(reservations);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
 }


### PR DESCRIPTION
### What I did

* Implementé la funcionalidad para que el propietario de un ambiente pueda bloquear un rango específico de tiempo (no solo por día completo).
* Agregué un nuevo endpoint para listar todas las fechas bloqueadas por el propietario (`Type = "OwnerBlocked"`) incluyendo información del ambiente.

---

### Why I did it

* Para permitir a los propietarios gestionar con mayor precisión la disponibilidad de sus ambientes, incluyendo horarios específicos.
* Para ofrecer una vista organizada de todas las fechas bloqueadas manualmente por los propietarios, útil para administración y auditoría.

---

### How I did it

* Se modificó el DTO `BlockAvailabilityRequest` para recibir `startDate` y `endDate` como timestamps en milisegundos.
* Se creó el método `BlockDateAsync` en el servicio `AvailabilityService`, con validaciones de permisos y rango de tiempo válido.
* Se añadió el método `GetOwnerBlockedAsync` al servicio, que obtiene todas las no disponibilidades del tipo `"OwnerBlocked"` asociadas al `ownerId`.
* Se implementó el método `GetOwnerBlockedByOwnerIdAsync` en el repositorio para consultar con `Include` la entidad `Environment` y su primera foto.
* Se agregó el endpoint `GET /api/Availability/owner-blocked` al controller, obteniendo el `ownerId` desde la cookie `publicId`.
