### PR TITLE
Feature/spacio 136/filter by detected objects

### DIFF
--- a/src/Application/Commands/Concretes/CreateEnvironmentCommand.cs
+++ b/src/Application/Commands/Concretes/CreateEnvironmentCommand.cs
@@ -85,11 +85,6 @@ public class CreateEnvironmentCommand(
             environment.Equipment = _dto.EquipmentJson;
         }
 
-        if (_dto.Request360Tour)
-        {
-            await _adminServiceAdapter.RequestTourAsync(environment.PublicId, _userId);
-        }
-
         await _repository.AddAsync(environment);
         await _repository.SaveChangesAsync();
 
@@ -107,6 +102,11 @@ public class CreateEnvironmentCommand(
                     FileId = uploaded.FileId,
                 });
             }
+        }
+
+        if (_dto.Request360Tour)
+        {
+            await _adminServiceAdapter.RequestTourAsync(environment.PublicId, _userId);
         }
 
         return _mapper.Map<EnvironmentDto>(environment);

--- a/src/Application/Commands/Concretes/CreateReservationCommand.cs
+++ b/src/Application/Commands/Concretes/CreateReservationCommand.cs
@@ -44,6 +44,11 @@ public class CreateReservationCommand(
             {
                 var resStart = date == startDateTime.Date ? startDateTime.TimeOfDay.TotalMilliseconds : 0;
                 var resEnd = date == endDateTime.Date ? endDateTime.TimeOfDay.TotalMilliseconds : 86400000;
+                var resStartTime = date == startDateTime.Date ? startDateTime.TimeOfDay : TimeSpan.Zero;
+                var resEndTime = date == endDateTime.Date ? endDateTime.TimeOfDay : TimeSpan.FromMinutes(1440); // Fin del día
+
+                var resStartMinutes = (int)resStartTime.TotalMinutes;
+                var resEndMinutes = (int)resEndTime.TotalMinutes;
 
                 var special = environment.SpecialAvailabilities.FirstOrDefault(sa => sa.Date.Date == date.Date);
                 if (special != null)
@@ -64,9 +69,9 @@ public class CreateReservationCommand(
                     var weekly = environment.WeeklySchedules.FirstOrDefault(ws => ws.DayOfWeek == dayOfWeek)
                         ?? throw new Exception($"El entorno no está disponible el día {date:dddd}.");
 
-                    if (resStart < weekly.StartTime || resEnd > weekly.EndTime)
+                    if (resStartMinutes < weekly.StartTime || resEndMinutes > weekly.EndTime)
                     {
-                        throw new Exception($"La reserva en {date:yyyy-MM-dd} debe estar entre {TimeSpan.FromMilliseconds(weekly.StartTime)} y {TimeSpan.FromMilliseconds(weekly.EndTime)}.");
+                        throw new Exception($"La reserva en {date:yyyy-MM-dd} debe estar entre {TimeSpan.FromMinutes(weekly.StartTime):hh\\:mm} y {TimeSpan.FromMinutes(weekly.EndTime):hh\\:mm}.");
                     }
                 }
             }

--- a/src/Application/Commands/Concretes/GetAvailableEquipmentCommand.cs
+++ b/src/Application/Commands/Concretes/GetAvailableEquipmentCommand.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using EnvironmentsService.Src.Application.Commands.Interfaces;
+using EnvironmentsService.Src.Application.DTOs.Get;
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Domain.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Commands.Concretes;
+
+public class GetAvailableEquipmentCommand(
+    GetAvailableEnvironmentsRequest request,
+    IEnvironmentRepository repository)
+    : ICommand<List<AvailableEquipmentDto>>
+{
+    private readonly IEnvironmentRepository _repository = repository;
+    private readonly GetAvailableEnvironmentsRequest _request = request;
+
+    public async Task<List<AvailableEquipmentDto>> ExecuteAsync()
+    {
+        var environments = await _repository.GetFilteredEnvironmentsAsync(_request);
+
+        var equipmentCounts = new Dictionary<string, int>();
+
+        foreach (var env in environments)
+        {
+            if (string.IsNullOrWhiteSpace(env.Equipment))
+            {
+                continue;
+            }
+
+            Dictionary<string, int>? equipmentDict = null;
+
+            try
+            {
+                equipmentDict = JsonSerializer.Deserialize<Dictionary<string, int>>(env.Equipment);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (equipmentDict == null)
+            {
+                continue;
+            }
+
+            foreach (var key in equipmentDict.Keys.Distinct())
+            {
+                if (equipmentDict[key] <= 0)
+                {
+                    continue;
+                }
+
+                if (equipmentCounts.ContainsKey(key))
+                {
+                    equipmentCounts[key]++;
+                }
+                else
+                {
+                    equipmentCounts[key] = 1;
+                }
+            }
+        }
+
+        return [.. equipmentCounts
+            .Select(kv => new AvailableEquipmentDto
+            {
+                Name = kv.Key,
+                Count = kv.Value,
+            })
+            .OrderByDescending(e => e.Count)];
+    }
+}

--- a/src/Application/DTOs/Get/AvailableEquipmentDto.cs
+++ b/src/Application/DTOs/Get/AvailableEquipmentDto.cs
@@ -1,0 +1,8 @@
+namespace EnvironmentsService.Src.Application.DTOs.Get;
+
+public class AvailableEquipmentDto
+{
+    public string Name { get; set; } = string.Empty;
+
+    public int Count { get; set; }
+}

--- a/src/Application/DTOs/Get/GetAllEnvironmentDto.cs
+++ b/src/Application/DTOs/Get/GetAllEnvironmentDto.cs
@@ -22,6 +22,8 @@ public class GetAllEnvironmentDto
 
     public Guid? Tour360Id { get; set; }
 
+    public Guid OwnerId { get; set; }
+
     public bool InstantBooking { get; set; }
 
     public int MinRentalTime { get; set; }

--- a/src/Application/DTOs/GetRequest/GetAvailableEnvironmentsRequest.cs
+++ b/src/Application/DTOs/GetRequest/GetAvailableEnvironmentsRequest.cs
@@ -14,6 +14,8 @@ public class GetAvailableEnvironmentsRequest
 
     public List<(string AreaPublicKey, int MinQuantity)>? Areas { get; set; }
 
+    public Dictionary<string, int>? EquipmentRequired { get; set; }
+
     public bool? InstantBookingRequired { get; set; }
 
     public decimal? MinPrice { get; set; }

--- a/src/Application/DTOs/Responses/OwnerBlockedAvailabilityDto.cs
+++ b/src/Application/DTOs/Responses/OwnerBlockedAvailabilityDto.cs
@@ -1,7 +1,9 @@
-namespace EnvironmentsService.Src.Application;
+namespace EnvironmentsService.Src.Application.DTOs.Responses;
 
 public class OwnerBlockedAvailabilityDto
 {
+    public Guid EnvironmentId { get; set; } = Guid.NewGuid();
+
     public string EnvironmentTitle { get; set; } = string.Empty;
 
     public string? EnvironmentPhotoUrl { get; set; }

--- a/src/Application/Interfaces/IAvailabilityService.cs
+++ b/src/Application/Interfaces/IAvailabilityService.cs
@@ -1,5 +1,6 @@
 using EnvironmentsService.src.Application.DTOs.Create;
 using EnvironmentsService.Src.Application.DTOs.Get;
+using EnvironmentsService.Src.Application.DTOs.Responses;
 
 namespace EnvironmentsService.Src.Application.Interfaces;
 

--- a/src/Application/Interfaces/IEnvironmentService.cs
+++ b/src/Application/Interfaces/IEnvironmentService.cs
@@ -15,4 +15,6 @@ public interface IEnvironmentService
     Task<EnvironmentDto> CreateAsync(CreateEnvironmentDto dto, Guid userId);
 
     Task UpdateDetectedObjectsAsync(Guid publicId, Dictionary<string, int> detectedObjects);
+
+    Task<List<AvailableEquipmentDto>> GetAvailableEquipmentAsync(GetAvailableEnvironmentsRequest request);
 }

--- a/src/Application/Pipelines/EnvironmentPostFilterPipeline.cs
+++ b/src/Application/Pipelines/EnvironmentPostFilterPipeline.cs
@@ -1,0 +1,17 @@
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Pipelines;
+
+public class EnvironmentPostFilterPipeline(IEnumerable<IEnvironmentPostFilterStrategy> strategies)
+{
+    public IEnumerable<Domain.Entities.Environment> ApplyFilters(IEnumerable<Domain.Entities.Environment> environments, GetAvailableEnvironmentsRequest request)
+    {
+        foreach (var strategy in strategies)
+        {
+            environments = strategy.Apply(environments, request);
+        }
+
+        return environments;
+    }
+}

--- a/src/Application/Services/AvailabilityService.cs
+++ b/src/Application/Services/AvailabilityService.cs
@@ -1,5 +1,6 @@
 using EnvironmentsService.src.Application.DTOs.Create;
 using EnvironmentsService.Src.Application.DTOs.Get;
+using EnvironmentsService.Src.Application.DTOs.Responses;
 using EnvironmentsService.Src.Application.Interfaces;
 using EnvironmentsService.Src.Domain.Entities;
 using EnvironmentsService.Src.Domain.Interfaces;
@@ -65,6 +66,7 @@ public class AvailabilityService(
 
         return [.. blocked.Select(n => new OwnerBlockedAvailabilityDto
         {
+            EnvironmentId = n.EnvironmentId,
             EnvironmentTitle = n.Environment.Title,
             EnvironmentPhotoUrl = n.Environment.Photos.OrderBy(p => p.Order).FirstOrDefault()?.Url,
             StartDate = n.StartDate,

--- a/src/Application/Services/EnvironmentService.cs
+++ b/src/Application/Services/EnvironmentService.cs
@@ -65,4 +65,10 @@ public class EnvironmentService(
         var command = new UpdateDetectedObjectsCommand(_repository, publicId, detectedObjects);
         await command.ExecuteAsync();
     }
+
+    public async Task<List<AvailableEquipmentDto>> GetAvailableEquipmentAsync(GetAvailableEnvironmentsRequest request)
+    {
+        var command = new GetAvailableEquipmentCommand(request, _repository);
+        return await command.ExecuteAsync();
+    }
 }

--- a/src/Application/Strategies/Concretes/GetEnvironments/DateAvailabilityFilterStrategy.cs
+++ b/src/Application/Strategies/Concretes/GetEnvironments/DateAvailabilityFilterStrategy.cs
@@ -22,17 +22,21 @@ public class DateAvailabilityFilterStrategy : IEnvironmentFilterStrategy
                 .Select(offset => start.Date.AddDays(offset))
                 .ToList();
 
+            if (request.EnvironmentTypePublicKey == "hospedajes")
+            {
+                return query;
+            }
+
             foreach (var date in dates)
             {
                 var dow = (int)date.DayOfWeek;
                 var startMinutes = date == start.Date ? (start.Hour * 60) + start.Minute : 0;
                 var endMinutes = date == end.Date ? (end.Hour * 60) + end.Minute : 1440;
 
-                query = query.Where(e =>
-                    e.WeeklySchedules.Any(ws =>
-                        ws.DayOfWeek == dow &&
-                        ws.StartTime <= startMinutes &&
-                        ws.EndTime >= endMinutes));
+                // query = query.Where(e =>
+                //     e.WeeklySchedules.Any(ws =>
+                //         ws.DayOfWeek == dow &&
+                //         ws.StartTime <= endMinutes && ws.EndTime >= startMinutes));
             }
         }
 

--- a/src/Application/Strategies/Concretes/GetEnvironments/FilterByEquipmentStrategy.cs
+++ b/src/Application/Strategies/Concretes/GetEnvironments/FilterByEquipmentStrategy.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+using EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+namespace EnvironmentsService.Src.Application.Strategies.Concretes.GetEnvironments;
+
+public class FilterByEquipmentStrategy : IEnvironmentPostFilterStrategy
+{
+    public IEnumerable<Domain.Entities.Environment> Apply(
+        IEnumerable<Domain.Entities.Environment> environments,
+        GetAvailableEnvironmentsRequest request)
+    {
+        if (request.EquipmentRequired == null || !request.EquipmentRequired.Any())
+        {
+            return environments;
+        }
+
+        return environments.Where(env =>
+        {
+            try
+            {
+                var eq = JsonSerializer.Deserialize<Dictionary<string, int>>(env.Equipment);
+                if (eq == null)
+                {
+                    return false;
+                }
+
+                return request.EquipmentRequired.All(req =>
+                    eq.TryGetValue(req.Key, out var qty) && qty >= req.Value);
+            }
+            catch
+            {
+                return false;
+            }
+        });
+    }
+}

--- a/src/Application/Strategies/Interfaces/IEnvironmentPostFilterStrategy.cs
+++ b/src/Application/Strategies/Interfaces/IEnvironmentPostFilterStrategy.cs
@@ -1,0 +1,8 @@
+using EnvironmentsService.Src.Application.DTOs.GetRequest;
+
+namespace EnvironmentsService.Src.Application.Strategies.Interfaces;
+
+public interface IEnvironmentPostFilterStrategy
+{
+    IEnumerable<Domain.Entities.Environment> Apply(IEnumerable<Domain.Entities.Environment> environments, GetAvailableEnvironmentsRequest request);
+}

--- a/src/Domain/Interfaces/IEnvironmentRepository.cs
+++ b/src/Domain/Interfaces/IEnvironmentRepository.cs
@@ -20,4 +20,6 @@ public interface IEnvironmentRepository
     Task AddImageAsync(EnvironmentPhoto image);
 
     Task UpdateDetectedEquipmentAsync(Guid publicId, string serializedEquipment);
+
+    Task<List<Entities.Environment>> GetFilteredEnvironmentsAsync(GetAvailableEnvironmentsRequest request);
 }

--- a/src/Infraestructure/Repositories/EnvironmentRepository.cs
+++ b/src/Infraestructure/Repositories/EnvironmentRepository.cs
@@ -75,6 +75,14 @@ public class EnvironmentRepository(DbContext context, EnvironmentFilterPipeline 
         await _context.SaveChangesAsync();
     }
 
+    public async Task<List<Domain.Entities.Environment>> GetFilteredEnvironmentsAsync(GetAvailableEnvironmentsRequest request)
+    {
+        var baseQuery = GetBaseEnvironmentQuery();
+        var filteredQuery = _pipeline.ApplyFilters(baseQuery, request);
+
+        return await filteredQuery.ToListAsync();
+    }
+
     private IQueryable<Domain.Entities.Environment> GetBaseEnvironmentQuery()
     {
         return _context.Set<Domain.Entities.Environment>()

--- a/src/Infraestructure/Repositories/EnvironmentRepository.cs
+++ b/src/Infraestructure/Repositories/EnvironmentRepository.cs
@@ -6,10 +6,11 @@ using Microsoft.EntityFrameworkCore;
 
 namespace EnvironmentsService.Src.Infraestructure.Repositories;
 
-public class EnvironmentRepository(DbContext context, EnvironmentFilterPipeline pipeline) : IEnvironmentRepository
+public class EnvironmentRepository(DbContext context, EnvironmentFilterPipeline pipeline, EnvironmentPostFilterPipeline postPipeline) : IEnvironmentRepository
 {
     private readonly DbContext _context = context;
     private readonly EnvironmentFilterPipeline _pipeline = pipeline;
+    private readonly EnvironmentPostFilterPipeline _postPipeline = postPipeline;
 
     public async Task<(List<Domain.Entities.Environment> Environments, int TotalItems)> FilterEnvironmentsAsync(
     GetAvailableEnvironmentsRequest request, int page, int limit)
@@ -17,13 +18,16 @@ public class EnvironmentRepository(DbContext context, EnvironmentFilterPipeline 
         var baseQuery = GetBaseEnvironmentQuery();
         var filteredQuery = _pipeline.ApplyFilters(baseQuery, request);
 
-        var totalItems = await filteredQuery.CountAsync();
-        var environments = await filteredQuery
+        var resultsFromDb = await filteredQuery.ToListAsync();
+
+        var filteredInMemory = _postPipeline.ApplyFilters(resultsFromDb, request);
+
+        var paged = filteredInMemory
             .Skip((page - 1) * limit)
             .Take(limit)
-            .ToListAsync();
+            .ToList();
 
-        return (environments, totalItems);
+        return (paged, filteredInMemory.Count());
     }
 
     public async Task<(List<Domain.Entities.Environment> Environments, int TotalItems)> GetOwnerEnvironmentsAsync(

--- a/src/Infraestructure/Repositories/ReservationRepository.cs
+++ b/src/Infraestructure/Repositories/ReservationRepository.cs
@@ -80,7 +80,9 @@ public class ReservationRepository(DbContext context) : IReservationRepository
         var query = _context.Set<Reservation>()
             .Include(r => r.Environment)
                 .ThenInclude(e => e.Photos)
-            .Where(r => (r.RenterId == userId || r.OwnerId == userId) && r.Status == status);
+            .Include(r => r.TimeRanges)
+            .Include(r => r.Payments)
+            .Where(r => r.RenterId == userId || r.OwnerId == userId /* && r.Status == status */);
 
         var totalItems = await query.CountAsync();
         var reservations = await query

--- a/src/WebApi/Controllers/EnvironmentsController.cs
+++ b/src/WebApi/Controllers/EnvironmentsController.cs
@@ -72,4 +72,12 @@ public class EnvironmentsController(IEnvironmentService service) : ControllerBas
             return BadRequest(ex.Message);
         }
     }
+
+    [HttpPost("available-equipment")]
+    public async Task<IActionResult> GetAvailableEquipment(
+    [FromBody] GetAvailableEnvironmentsRequest request)
+    {
+        var result = await _service.GetAvailableEquipmentAsync(request);
+        return Ok(result);
+    }
 }

--- a/src/WebApi/Controllers/ReservationsController.cs
+++ b/src/WebApi/Controllers/ReservationsController.cs
@@ -28,6 +28,7 @@ public class ReservationsController(IReservationService service) : ControllerBas
         }
         catch (Exception ex)
         {
+            Console.WriteLine(ex);
             return BadRequest(new { mensaje = ex.Message });
         }
     }

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -68,7 +68,9 @@ builder.Services.AddScoped<IEnvironmentFilterStrategy, PriceFilterStrategy>();
 builder.Services.AddScoped<IEnvironmentFilterStrategy, ServiceFilterStrategy>();
 builder.Services.AddScoped<IEnvironmentFilterStrategy, AreaFilterStrategy>();
 builder.Services.AddScoped<IEnvironmentFilterStrategy, DateAvailabilityFilterStrategy>();
+builder.Services.AddScoped<IEnvironmentPostFilterStrategy, FilterByEquipmentStrategy>();
 builder.Services.AddScoped<EnvironmentFilterPipeline>();
+builder.Services.AddScoped<EnvironmentPostFilterPipeline>();
 
 builder.Services.AddScoped<ITourService, TourService>();
 builder.Services.AddScoped<ITourRepository, TourRepository>();


### PR DESCRIPTION
### What I did

Implemented two backend features:

1. A new filter strategy to allow filtering environments by required equipment and quantity.
2. An endpoint to retrieve available equipment options (object IDs and counts) based on current filters.

---

### Why I did it

To enhance the environment search functionality by:

* Letting users request only environments that include specific equipment in desired quantities.
* Dynamically showing which equipment filters are relevant and how many environments include each, improving UX in the frontend.

---

### How I did it

#### 1. Filter by Equipment with Quantity

* Added a new property `EquipmentRequired: Dictionary<string, int>` in `GetAvailableEnvironmentsRequest`.
* Created a new interface `IEnvironmentPostFilterStrategy` for filtering environments in-memory.
* Implemented `FilterByEquipmentPostStrategy` to deserialize the `Equipment` field and apply filtering logic based on required quantities.
* Introduced `EnvironmentPostFilterPipeline` to apply in-memory strategies after database filtering.
* Updated `EnvironmentRepository.FilterEnvironmentsAsync` to apply both SQL and in-memory filtering pipelines.

#### 2. Available Equipment Endpoint

* Created `GetAvailableEquipmentCommand` to count how many environments (post-filtering) contain each equipment object.
* Defined `AvailableEquipmentDto` to return object IDs with usage counts.
* Added endpoint `POST /api/environments/available-equipment` in `EnvironmentsController`.
* Integrated it with the service layer (`GetAvailableEquipmentAsync`) for reuse and consistency.