### PR TITLE
Feature/spacio 116/update debt with owner

### DIFF
--- a/src/Application/Commands/Concretes/CreateReservationCommand.cs
+++ b/src/Application/Commands/Concretes/CreateReservationCommand.cs
@@ -4,6 +4,7 @@ using AutoMapper;
 using EnvironmentsService.Src.Application.Commands.Interfaces;
 using EnvironmentsService.Src.Application.DTOs.Create;
 using EnvironmentsService.Src.Application.DTOs.Responses;
+using EnvironmentsService.Src.Application.Interfaces;
 using EnvironmentsService.Src.Domain.Entities.Booking;
 using EnvironmentsService.Src.Domain.Interfaces;
 
@@ -11,11 +12,13 @@ public class CreateReservationCommand(
     CreateReservationDto request,
     IEnvironmentRepository environmentRepo,
     IReservationRepository reservationRepo,
+    IAdminServiceAdapter adminServiceAdapter,
     IMapper mapper
 ) : ICommand<ReservationResponse>
 {
     private readonly IEnvironmentRepository _environmentRepo = environmentRepo;
     private readonly IReservationRepository _reservationRepo = reservationRepo;
+    private readonly IAdminServiceAdapter _adminServiceAdapter = adminServiceAdapter;
     private readonly IMapper _mapper = mapper;
 
     public async Task<ReservationResponse> ExecuteAsync()
@@ -77,7 +80,7 @@ public class CreateReservationCommand(
             }
         }
 
-        // Verificar límite de tiempo total
+        // Verify total time limit
         var existingReservations = await _reservationRepo.GetActiveReservationsByRenterAsync(request.RenterId);
         int totalTimeUnits = 0;
 
@@ -151,6 +154,13 @@ public class CreateReservationCommand(
         await _reservationRepo.AddAsync(reservation);
         await _reservationRepo.SaveChangesAsync();
         await transaction.CommitAsync();
+
+        await _adminServiceAdapter.RequestOwnerIncomeAsync(
+            environment.OwnerId,
+            reservation.Id,
+            request.TotalPrice,
+            request.Currency,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
 
         return _mapper.Map<ReservationResponse>(reservation);
     }

--- a/src/Application/Commands/Concretes/CreateReservationCommand.cs
+++ b/src/Application/Commands/Concretes/CreateReservationCommand.cs
@@ -155,12 +155,15 @@ public class CreateReservationCommand(
         await _reservationRepo.SaveChangesAsync();
         await transaction.CommitAsync();
 
-        await _adminServiceAdapter.RequestOwnerIncomeAsync(
+        if (environment.InstantBooking)
+        {
+            await _adminServiceAdapter.RequestOwnerIncomeAsync(
             environment.OwnerId,
             reservation.Id,
             request.TotalPrice,
             request.Currency,
             DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        }
 
         return _mapper.Map<ReservationResponse>(reservation);
     }

--- a/src/Application/Commands/Concretes/UpdateReservationStatusCommand.cs
+++ b/src/Application/Commands/Concretes/UpdateReservationStatusCommand.cs
@@ -1,18 +1,22 @@
 using AutoMapper;
 using EnvironmentsService.Src.Application.DTOs.Responses;
+using EnvironmentsService.Src.Application.Interfaces;
 using EnvironmentsService.Src.Domain.Interfaces;
 
 namespace EnvironmentsService.Src.Application.Commands.Concretes;
 
 public class UpdateReservationStatusCommand(
     Guid reservationPublicId,
+    Guid ownerId,
     string newStatus,
     IReservationRepository resRepo,
+    IAdminServiceAdapter adminServiceAdapter,
     IMapper mapper)
 {
     private readonly Guid _reservationPublicId = reservationPublicId;
     private readonly string _newStatus = newStatus.ToLower();
     private readonly IReservationRepository _resRepo = resRepo;
+    private readonly IAdminServiceAdapter _adminServiceAdapter = adminServiceAdapter;
     private readonly IMapper _mapper = mapper;
 
     public async Task<ReservationResponse> ExecuteAsync()
@@ -43,6 +47,13 @@ public class UpdateReservationStatusCommand(
             {
                 throw new Exception("Ya existe una reserva confirmada para este periodo.");
             }
+
+            await _adminServiceAdapter.RequestOwnerIncomeAsync(
+            ownerId,
+            reservation.Id,
+            reservation.TotalPrice,
+            reservation.Currency,
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
         }
 
         reservation.Status = _newStatus;

--- a/src/Application/Interfaces/IAdminServiceAdapter.cs
+++ b/src/Application/Interfaces/IAdminServiceAdapter.cs
@@ -3,4 +3,6 @@ namespace EnvironmentsService.Src.Application.Interfaces;
 public interface IAdminServiceAdapter
 {
     Task RequestTourAsync(Guid environmentId, Guid ownerId);
+
+    Task RequestOwnerIncomeAsync(Guid ownerId, Guid reservationId, decimal amount, string currency, long generatedAt);
 }

--- a/src/Application/Interfaces/IReservationService.cs
+++ b/src/Application/Interfaces/IReservationService.cs
@@ -12,7 +12,7 @@ public interface IReservationService
 
     Task<ReservationResponse?> GetByPublicIdAsync(Guid publicId);
 
-    Task<ReservationResponse> UpdateStatusAsync(Guid reservationPublicId, string newStatus);
+    Task<ReservationResponse> UpdateStatusAsync(Guid reservationPublicId, Guid ownerId, string newStatus);
 
     Task<List<ReservationResponse>> GetConflictingReservationsAsync(Guid environmentId, long start, long end);
 

--- a/src/Application/Services/ReservationService.cs
+++ b/src/Application/Services/ReservationService.cs
@@ -51,9 +51,9 @@ public class ReservationService(
         return reservation == null ? null : _mapper.Map<ReservationResponse>(reservation);
     }
 
-    public async Task<ReservationResponse> UpdateStatusAsync(Guid reservationPublicId, string newStatus)
+    public async Task<ReservationResponse> UpdateStatusAsync(Guid reservationPublicId, Guid ownerId, string newStatus)
     {
-        var command = new UpdateReservationStatusCommand(reservationPublicId, newStatus, _resRepo, _mapper);
+        var command = new UpdateReservationStatusCommand(reservationPublicId, ownerId, newStatus, _resRepo, _adminServiceAdapter, _mapper);
         return await command.ExecuteAsync();
     }
 

--- a/src/Application/Services/ReservationService.cs
+++ b/src/Application/Services/ReservationService.cs
@@ -12,17 +12,19 @@ using Microsoft.EntityFrameworkCore;
 public class ReservationService(
     IEnvironmentRepository environmentRepo,
     IReservationRepository reservationRepo,
+    IAdminServiceAdapter adminServiceAdapter,
     IMapper mapper) : IReservationService
 {
     private readonly IEnvironmentRepository _envRepo = environmentRepo;
     private readonly IReservationRepository _resRepo = reservationRepo;
+    private readonly IAdminServiceAdapter _adminServiceAdapter = adminServiceAdapter;
     private readonly IMapper _mapper = mapper;
 
     public async Task<ReservationResponse> CreateAsync(CreateReservationRequest request, Guid renterId)
     {
         var dto = _mapper.Map<CreateReservationDto>(request);
         dto.RenterId = renterId;
-        var command = new CreateReservationCommand(dto, _envRepo, _resRepo, _mapper);
+        var command = new CreateReservationCommand(dto, _envRepo, _resRepo, _adminServiceAdapter, _mapper);
         return await command.ExecuteAsync();
     }
 

--- a/src/Infraestructure/Adapters/AdminServiceAdapter.cs
+++ b/src/Infraestructure/Adapters/AdminServiceAdapter.cs
@@ -7,7 +7,6 @@ namespace EnvironmentsService.Src.Infraestructure.Adapters;
 public class AdminServiceAdapter(HttpClient client) : IAdminServiceAdapter
 {
     private readonly HttpClient _client = client;
-    private readonly string _requestUrl = "/api/tour360requests";
 
     public async Task RequestTourAsync(Guid environmentId, Guid ownerId)
     {
@@ -22,7 +21,34 @@ public class AdminServiceAdapter(HttpClient client) : IAdminServiceAdapter
             Encoding.UTF8,
             "application/json");
 
-        var request = new HttpRequestMessage(HttpMethod.Post, _requestUrl)
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/tour360requests")
+        {
+            Content = content,
+        };
+
+        request.Headers.Add("Cookie", $"publicId={ownerId}");
+
+        var response = await _client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task RequestOwnerIncomeAsync(Guid ownerId, Guid reservationId, decimal amount, string currency, long generatedAt)
+    {
+        var payload = new
+        {
+            OwnerId = ownerId,
+            ReservationId = reservationId,
+            Amount = amount,
+            Currency = currency,
+            GeneratedAt = generatedAt,
+        };
+
+        var content = new StringContent(
+            JsonSerializer.Serialize(payload),
+            Encoding.UTF8,
+            "application/json");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/owners/earnings")
         {
             Content = content,
         };

--- a/src/WebApi/Controllers/ReservationsController.cs
+++ b/src/WebApi/Controllers/ReservationsController.cs
@@ -72,9 +72,16 @@ public class ReservationsController(IReservationService service) : ControllerBas
     [HttpPatch("{publicId:guid}/status")]
     public async Task<IActionResult> UpdateStatus(Guid publicId, [FromBody] UpdateReservationStatusDto request)
     {
+        var publicIdClaim = Request.Cookies["publicId"];
+
+        if (publicIdClaim == null || !Guid.TryParse(publicIdClaim, out var userPublicId))
+        {
+            return Unauthorized("Invalid or missing user public_id");
+        }
+
         try
         {
-            var updated = await _service.UpdateStatusAsync(publicId, request.Status);
+            var updated = await _service.UpdateStatusAsync(publicId, userPublicId, request.Status);
             return Ok(updated);
         }
         catch (Exception ex)


### PR DESCRIPTION
**What I Did:**

* Implemented a new **`AdminServiceAdapter`** to interact with the **Admin Service** for creating owner income whenever a reservation is made.
* Created a method in the adapter (**`RequestOwnerIncomeAsync`**) to send a **POST** request to the **`/api/owners/earnings`** endpoint of the Admin Service, passing the necessary data (OwnerId, ReservationId, Amount, Currency, GeneratedAt).
* Updated the **`CreateReservationCommand`** to call the **`AdminServiceAdapter`** after a reservation is successfully created. The adapter will be responsible for notifying the **Admin Service** to create the corresponding owner income.

**How I Did It:**

* **`AdminServiceAdapter`**: This class is designed to handle HTTP communication with the **Admin Service**. It uses **`HttpClient`** to send requests to the **Admin Service** API with a serialized payload that contains income details (owner, reservation, amount, etc.).
* **`CreateReservationCommand`**: After successfully creating the reservation in the **`CreateReservationCommand`**, the command calls the adapter’s **`RequestOwnerIncomeAsync`** method to notify the **Admin Service** and create the owner income.
* **Error Handling**: The **adapter** ensures that the HTTP request is properly sent and that errors are logged or handled if the request fails.

**Why I Did It:**

* To ensure **data consistency** between the **reservation creation** and the **owner income** tracking system. When a reservation is made, it is critical that the corresponding income is created and recorded in the **Admin Service**.
* To **separate concerns**: The **`AdminServiceAdapter`** handles the external service communication, and **`CreateReservationCommand`** focuses on the core business logic for creating a reservation.
* To ensure a **clean architecture** by using an **adapter pattern**, which isolates the external API call from the core application logic, making it easier to modify or extend in the future.
